### PR TITLE
fix: only run token discovery endpoint on mainnet

### DIFF
--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -114,7 +114,7 @@ async function cacheTokensList() {
   }
 }
 
-if (!timerStarted) {
+if (!timerStarted && process.env.REACT_APP_ENVIRONMENT === 'mainnet') {
   timerStarted = true;
   cacheTokensList();
   setInterval(() => cacheTokensList(), TIME_INTERVAL);


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

The non-mainnet endpoints (devnet, testnet) were also running BigQuery queries, which is an unnecessary drain on resources. devnet and testnet don't have a tokens page.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
