### PR TITLE
fix: more GCP fixes

### DIFF
--- a/server/routes/v1/index.js
+++ b/server/routes/v1/index.js
@@ -21,7 +21,9 @@ api.use('/transactions/:id', getTransaction);
 api.use('/paystrings/:id', getPayString);
 api.use('/nunl', nUNL);
 api.use('/quorum', getQuorum);
-api.use('/token/top', getTokenDiscovery);
+if (process.env.REACT_APP_ENVIRONMENT === 'mainnet') {
+  api.use('/token/top', getTokenDiscovery);
+}
 api.use(
   '/token/:currencyCode.:issuerAddress?/offers/:pairCurrencyCode.:pairIssuerAddress?',
   getOffers

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -4,10 +4,12 @@ const rippled = require('../../lib/rippled');
 const log = require('../../lib/logger')({ name: 'token discovery' });
 
 // whether this is running in the prod environment (or in dev/staging)
-// for the purpose of running locally, this equals true if the env var doesn't exist
+// for the purpose of running locally, this equals false if the env var doesn't exist
+// DO NOT SET TO TRUE UNLESS YOU'RE SURE ABOUT BIGQUERY USAGE
+// aka don't let the site run after you're done using it, because it'll cost $$
 const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK
   ? process.env.REACT_APP_MAINNET_LINK.includes('xrpl.org')
-  : true;
+  : false;
 // how long the auto-caching should run in dev and staging environments
 const TIME_TO_TEST = 1000 * 60 * 60 * 1; // 1 hour
 

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -9,9 +9,9 @@ const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK
   ? process.env.REACT_APP_MAINNET_LINK.includes('xrpl.org')
   : true;
 // how long the auto-caching should run in dev and staging environments
-const TIME_TO_TEST = 1000 * 60 * 10; // 10 minutes
+const TIME_TO_TEST = 1000 * 60 * 60 * 1; // 1 hour
 
-const TIME_INTERVAL = 1000 * 60 * 5; // 5 minutes
+const TIME_INTERVAL = 1000 * 60 * 30; // 30 minutes
 
 const NUM_TOKENS_FETCH_ALL = 10;
 

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -3,7 +3,9 @@ const rippled = require('../../lib/rippled');
 
 const log = require('../../lib/logger')({ name: 'token discovery' });
 
-const IS_PROD_ENV = process.env.RELEASE_ENV ? process.env.RELEASE_ENV.includes('prod-') : true;
+const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK
+  ? process.env.REACT_APP_MAINNET_LINK.includes('xrpl.org')
+  : true;
 // how long the auto-caching should run in dev and staging environments
 const TIME_TO_TEST = 1000 * 60 * 10; // 10 minutes
 

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -11,9 +11,9 @@ const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK?.includes('xrpl.org');
 // How long the auto-caching should run in dev and staging environments
 // We want to turn it off after some time so it doesn't run when we don't need it, which costs us
 // money per BigQuery query
-const TIME_TO_TEST = 1000 * 60 * 60 * 1; // 1 hour
+const TIME_TO_TEST = 1000 * 60 * 60 * 6; // 6 hours (2 tests)
 
-const TIME_INTERVAL = 1000 * 60 * 30; // 30 minutes
+const TIME_INTERVAL = 1000 * 60 * 60 * 3; // 3 hours
 
 const NUM_TOKENS_FETCH_ALL = 10;
 

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -153,6 +153,8 @@ module.exports = async (req, res) => {
       cachedTokensList.time != null &&
       Date.now() - cachedTokensList.time > TIME_INTERVAL * 2
     ) {
+      cachedTokensList.tokens = [];
+      cachedTokensList.time = null;
       startCaching();
     }
     while (cachedTokensList.tokens.length === 0) {

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -7,9 +7,7 @@ const log = require('../../lib/logger')({ name: 'token discovery' });
 // For the purpose of running locally, this equals false if the env var doesn't exist
 // DO NOT SET TO TRUE UNLESS YOU'RE SURE ABOUT BIGQUERY USAGE
 // aka don't let the site run after you're done using it, because it'll cost $$
-const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK
-  ? process.env.REACT_APP_MAINNET_LINK.includes('xrpl.org')
-  : false;
+const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK?.includes('xrpl.org');
 // How long the auto-caching should run in dev and staging environments
 // We want to turn it off after some time so it doesn't run when we don't need it, which costs us
 // money per BigQuery query
@@ -128,22 +126,23 @@ async function cacheTokensList() {
 // Starts the caching process for bigquery
 function startCaching() {
   // Only run if on mainnet (the tokens page doesn't exist on devnet/testnet)
-  if (process.env.REACT_APP_ENVIRONMENT === 'mainnet') {
-    // Initialize the cache
-    cacheTokensList();
-    // Cache every TIME_INTERVAL ms (only starts after one interval)
-    const intervalId = setInterval(() => cacheTokensList(), TIME_INTERVAL);
-    // Stop the auto-running of the caching in the previous line after TIME_TO_TEST ms
-    // Only do this if not in the prod env, so we don't have excessive BigQuery queries when we're
-    // not actually using what's in the dev and staging environments
-    // We don't want regular caching to stop in prod, though, because then a missed cache would
-    // result in a several-second delay while the query is re-run, and this is a poor UX
-    if (!IS_PROD_ENV) {
-      setTimeout(() => {
-        log.info('stopping caching tokens');
-        clearInterval(intervalId);
-      }, TIME_TO_TEST);
-    }
+  if (process.env.REACT_APP_ENVIRONMENT !== 'mainnet') {
+    return;
+  }
+  // Initialize the cache
+  cacheTokensList();
+  // Cache every TIME_INTERVAL ms (only starts after one interval)
+  const intervalId = setInterval(() => cacheTokensList(), TIME_INTERVAL);
+  // Stop the auto-running of the caching in the previous line after TIME_TO_TEST ms
+  // Only do this if not in the prod env, so we don't have excessive BigQuery queries when we're
+  // not actually using what's in the dev and staging environments
+  // We don't want regular caching to stop in prod, though, because then a missed cache would
+  // result in a several-second delay while the query is re-run, and this is a poor UX
+  if (!IS_PROD_ENV) {
+    setTimeout(() => {
+      log.info('stopping caching tokens');
+      clearInterval(intervalId);
+    }, TIME_TO_TEST);
   }
 }
 

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -3,14 +3,14 @@ const rippled = require('../../lib/rippled');
 
 const log = require('../../lib/logger')({ name: 'token discovery' });
 
-// whether this is running in the prod environment (or in dev/staging)
-// for the purpose of running locally, this equals false if the env var doesn't exist
+// Whether this is running in the prod environment (or in dev/staging)
+// For the purpose of running locally, this equals false if the env var doesn't exist
 // DO NOT SET TO TRUE UNLESS YOU'RE SURE ABOUT BIGQUERY USAGE
 // aka don't let the site run after you're done using it, because it'll cost $$
 const IS_PROD_ENV = process.env.REACT_APP_MAINNET_LINK
   ? process.env.REACT_APP_MAINNET_LINK.includes('xrpl.org')
   : false;
-// how long the auto-caching should run in dev and staging environments
+// How long the auto-caching should run in dev and staging environments
 // We want to turn it off after some time so it doesn't run when we don't need it, which costs us
 // money per BigQuery query
 const TIME_TO_TEST = 1000 * 60 * 60 * 1; // 1 hour
@@ -125,13 +125,13 @@ async function cacheTokensList() {
   }
 }
 
-// starts the caching process for bigquery
+// Starts the caching process for bigquery
 function startCaching() {
-  // only run if on mainnet (the tokens page doesn't exist on devnet/testnet)
+  // Only run if on mainnet (the tokens page doesn't exist on devnet/testnet)
   if (process.env.REACT_APP_ENVIRONMENT === 'mainnet') {
-    // initialize the cache
+    // Initialize the cache
     cacheTokensList();
-    // cache every TIME_INTERVAL ms (only starts after one interval)
+    // Cache every TIME_INTERVAL ms (only starts after one interval)
     const intervalId = setInterval(() => cacheTokensList(), TIME_INTERVAL);
     // Stop the auto-running of the caching in the previous line after TIME_TO_TEST ms
     // Only do this if not in the prod env, so we don't have excessive BigQuery queries when we're
@@ -158,7 +158,7 @@ module.exports = async (req, res) => {
   // Running the BigQuery query costs money. Don't let it run if you don't need to.
   log.info(`getting token discovery`);
   try {
-    // if it's been a while since caching happened in the non-prod envs, then restart the caching
+    // If it's been a while since caching happened in the non-prod envs, then restart the caching
     // (needed because `startCaching` turns off caching after TIME_TO_TEST for non-prod envs)
     if (
       // true if in dev or staging
@@ -170,11 +170,11 @@ module.exports = async (req, res) => {
       cachedTokensList.time != null &&
       // true if some time has passed since the cache was last updated (i.e. `startCaching` was
       // turned off)
-      // this uses `TIME_INTERVAL * 2` to prevent race conditions around `TIME_INTERVAL`, in case
+      // This uses `TIME_INTERVAL * 2` to prevent race conditions around `TIME_INTERVAL`, in case
       // the cache just took some time to load but `startCaching` has already been triggered
       Date.now() - cachedTokensList.time > TIME_INTERVAL * 2
     ) {
-      // reset the cache so the API call waits below until it's been refilled
+      // Reset the cache so the API call waits below until it's been refilled
       cachedTokensList.tokens = [];
       cachedTokensList.time = null;
       startCaching();


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* For dev and staging environments, it only runs the caching for 1 hour before stopping (and starting again when someone calls the endpoint again).
* Changes the running of the BQ instance to every half hour.
* Removes the `token/top` endpoint for devnet and testnet.

### Context of Change

BQ queries happening too often

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

Not worth doing it here for a quick bugfix

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. The code works as designed locally. It also works as designed on devnet.
