### PR TITLE
fix: actually fix the tokens page

### DIFF
--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -83,6 +83,8 @@ async function getTokensList() {
   options = { query, location: 'US' };
   const [rankedTokens] = await bigQuery.query(options);
 
+  // This is running in mostly series instead of aggressively parallel on purpose.
+  // It prevents the Explorer from getting caught by rate-limiting on the rippled node.
   for (let i = 0; i <= NUM_TOKENS_FETCH_ALL; i += 1) {
     const { issuer, currency } = rankedTokens[i];
     const promises = [];

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -89,6 +89,7 @@ async function getTokensList() {
     promises.push(getAccountInfo(issuer, currency));
     promises.push(getExchangeRate(issuer, currency));
     try {
+      // eslint-disable-next-line no-await-in-loop -- okay here, helps run slower so we don't get rate limited
       const [accountInfo, exchangeRate] = await Promise.all(promises);
 
       const { domain, gravatar, obligations } = accountInfo;
@@ -103,7 +104,7 @@ async function getTokensList() {
       rankedTokens[i] = newInfo;
     } catch (error) {
       log.error(error);
-      return;
+      return undefined;
     }
   }
 

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -100,7 +100,6 @@ async function getTokensList() {
         obligations,
         exchangeRate,
       };
-      log.warn(newInfo);
       rankedTokens[i] = newInfo;
     } catch (error) {
       log.error(error);
@@ -136,7 +135,6 @@ async function cacheTokensList() {
   try {
     log.info('caching tokens');
     const tokens = await getTokensList();
-    log.warn('returned', tokens);
     cachedTokensList.tokens = tokens;
     cachedTokensList.time = Date.now();
   } catch (error) {

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -108,27 +108,6 @@ async function getTokensList() {
   }
 
   return rankedTokens;
-
-  // return Promise.all(promises)
-  //   .then(results => {
-  //     for (let i = 0; i < results.length; i += 2) {
-  //       const tokenIndex = i / 2;
-  //       const { domain, gravatar, obligations } = results[i];
-  //       const exchangeRate = results[i + 1];
-  //       const newInfo = {
-  //         ...rankedTokens[tokenIndex],
-  //         domain,
-  //         gravatar,
-  //         obligations,
-  //         exchangeRate,
-  //       };
-  //       rankedTokens[tokenIndex] = newInfo;
-  //     }
-  //     return rankedTokens;
-  //   })
-  //   .catch(error => {
-  //     log.error(error);
-  //   });
 }
 
 async function cacheTokensList() {


### PR DESCRIPTION
## High Level Overview of Change

This PR actually fixes the problems that https://livenet.xrpl.org/tokens was having. It turns out that the 40 queries that are needed for this page (4 for each of the 10 tokens) triggers the rate limiter. This PR runs those queries slightly more in series, instead of in parallel as it was doing before. It doesn't matter if it takes extra time, because this doesn't run very often.

### Context of Change

Tokens page went down with all the changes to our rippled nodes last week

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

not worth the effort for a quick bugfix

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Works locally.
