### PR TITLE
chore: update prod Node to v14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13
+FROM node:14
 MAINTAINER Ripple Operations <ops@ripple.com>
 
 RUN mkdir /explorer


### PR DESCRIPTION
## High Level Overview of Change

We are using Node v13 in our deployment environments, which is a version of Node that is no longer supported. This PR changes that and upgrades to v14. Ideally we should upgrade to 16, but that seemed like too big of a change to do now.

### Context of Change

Deploys were failing because Node v13 doesn't support optional chaining.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Deployment to the dev env worked.
