### PR TITLE
fix: remove Top Trading Pairs table from non-mainnet Explorers

### DIFF
--- a/src/containers/Token/index.js
+++ b/src/containers/Token/index.js
@@ -11,8 +11,7 @@ import NoMatch from '../NoMatch';
 import './styles.css';
 import { analytics, ANALYTIC_TYPES, NOT_FOUND, BAD_REQUEST } from '../shared/utils';
 
-const MODE = process.env.REACT_APP_ENVIRONMENT;
-const IS_MAINNET = MODE === 'mainnet';
+const IS_MAINNET = process.env.REACT_APP_ENVIRONMENT === 'mainnet';
 
 const ERROR_MESSAGES = {};
 ERROR_MESSAGES[NOT_FOUND] = {

--- a/src/containers/Token/index.js
+++ b/src/containers/Token/index.js
@@ -11,6 +11,9 @@ import NoMatch from '../NoMatch';
 import './styles.css';
 import { analytics, ANALYTIC_TYPES, NOT_FOUND, BAD_REQUEST } from '../shared/utils';
 
+const MODE = process.env.REACT_APP_ENVIRONMENT;
+const IS_MAINNET = MODE === 'mainnet';
+
 const ERROR_MESSAGES = {};
 ERROR_MESSAGES[NOT_FOUND] = {
   title: 'account_not_found',
@@ -72,7 +75,7 @@ class Token extends Component {
     ) : (
       <div className="token-page">
         {accountId && <TokenHeader accountId={accountId} currency={currency} t={t} />}
-        {accountId && <DEXPairs accountId={accountId} currency={currency} t={t} />}
+        {accountId && IS_MAINNET && <DEXPairs accountId={accountId} currency={currency} t={t} />}
         {accountId && <TokenTransactionsTable accountId={accountId} currency={currency} t={t} />}
         {!accountId && (
           <div style={{ textAlign: 'center', fontSize: '14px' }}>


### PR DESCRIPTION
## High Level Overview of Change

The `Top Trading Pairs` table shows up on a page for a token (e.g. https://livenet.xrpl.org/token/534F4C4F00000000000000000000000000000000.rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz). It also uses the top tokens endpoint. This endpoint doesn't exist on testnet/devnet, and the data is also not useful on testnet/devnet, because BigQuery only contains data for mainnet.

### Context of Change

This should have been handled alongside https://github.com/xpring-eng/explorer/pull/97, but it was missed.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

Before:
![image](https://user-images.githubusercontent.com/8029314/148294511-cbcc3e9b-1ed6-49b5-b9fa-0f58df308bd5.png)

After:
![image](https://user-images.githubusercontent.com/8029314/148294340-6bd0ced5-6ff5-4e10-8089-76dbb7205e8f.png)

This change only happens on devnet/testnet; mainnet will still remain the same.

## Test Plan

CI passes. Fix is fairly simple.
