### PR TITLE
fix: expand search currency regex to include longer currencies

### DIFF
--- a/src/containers/Header/Search.jsx
+++ b/src/containers/Header/Search.jsx
@@ -13,6 +13,7 @@ import {
   ANALYTIC_TYPES,
   CURRENCY_REGEX,
   DECIMAL_REGEX,
+  FULL_CURRENCY_REGEX,
   HASH_REGEX,
 } from '../shared/utils';
 import './search.css';
@@ -33,7 +34,10 @@ const getIdType = id => {
   if (isValidPayString(id) || isValidPayString(id.replace('@', '$'))) {
     return 'paystrings';
   }
-  if (CURRENCY_REGEX.test(id) && isValidClassicAddress(id.split('.')[1])) {
+  if (
+    (CURRENCY_REGEX.test(id) || FULL_CURRENCY_REGEX.test(id)) &&
+    isValidClassicAddress(id.split('.')[1])
+  ) {
     return 'token';
   }
 

--- a/src/containers/Header/test/Search.test.js
+++ b/src/containers/Header/test/Search.test.js
@@ -44,19 +44,33 @@ describe('Header component', () => {
     const ledgerIndex = '123456789';
     const rippleAddress = 'rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX';
     const hash = '59239EA78084F6E2F288473F8AE02F3E6FC92F44BDE59668B5CAE361D3D32838';
+    const token1 = 'cny.rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK';
+    const token2 = '534f4c4f00000000000000000000000000000000.rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz';
     const invalidString = '123invalid';
 
     input.simulate('keyDown', { key: 'a' });
     expect(window.location.pathname).toEqual('/');
+
     input.instance().value = ledgerIndex;
     input.simulate('keyDown', { key: 'Enter' });
     expect(window.location.pathname).toEqual(`/ledgers/${ledgerIndex}`);
+
     input.instance().value = rippleAddress;
     input.simulate('keyDown', { key: 'Enter' });
     expect(window.location.pathname).toEqual(`/accounts/${rippleAddress}`);
+
     input.instance().value = hash;
     input.simulate('keyDown', { key: 'Enter' });
     expect(window.location.pathname).toEqual(`/transactions/${hash}`);
+
+    input.instance().value = token1;
+    input.simulate('keyDown', { key: 'Enter' });
+    expect(window.location.pathname).toEqual(`/token/${token1}`);
+
+    input.instance().value = token2;
+    input.simulate('keyDown', { key: 'Enter' });
+    expect(window.location.pathname).toEqual(`/token/${token2}`);
+
     input.instance().value = invalidString;
     input.simulate('keyDown', { key: 'Enter' });
     expect(window.location.pathname).toEqual(`/search/${invalidString}`);

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -24,6 +24,7 @@ export const DECIMAL_REGEX = /^\d+$/;
 export const RIPPLE_ADDRESS_REGEX = /^r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
 export const HASH_REGEX = /[0-9A-F]{64}/i;
 export const CURRENCY_REGEX = /^[a-zA-Z]{3,}\.r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
+export const FULL_CURRENCY_REGEX = /^[0-9A-F]{40}\.r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
 
 export const UP_COLOR = '#2BCB96';
 export const DOWN_COLOR = '#F23548';

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -22,9 +22,9 @@ export const BAD_REQUEST = 400;
 
 export const DECIMAL_REGEX = /^\d+$/;
 export const RIPPLE_ADDRESS_REGEX = /^r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
-export const HASH_REGEX = /[0-9A-F]{64}/i;
+export const HASH_REGEX = /[0-9A-Fa-f]{64}/i;
 export const CURRENCY_REGEX = /^[a-zA-Z]{3,}\.r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
-export const FULL_CURRENCY_REGEX = /^[0-9A-F]{40}\.r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
+export const FULL_CURRENCY_REGEX = /^[0-9A-Fa-f]{40}\.r[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]{27,35}$/;
 
 export const UP_COLOR = '#2BCB96';
 export const DOWN_COLOR = '#F23548';


### PR DESCRIPTION
## High Level Overview of Change

This PR adds another currency regex for non-standard currency codes that are still in the 40-digit hex form instead of the 3-digit letter form.

### Context of Change

If you want to get information about a token like `534F4C4F00000000000000000000000000000000.rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz`, which does exist on the ledger, the search won't work properly. You have to go directly to the URL.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

The search now works properly.

## Test Plan

Tested the fix by hand. Added tests.
