### PR TITLE
Add logic to use a regular node for gateway_balances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ RIPPLED_WS_PORT=51233
 RIPPLED_RPC_PORT=51234
 RIPPLED_PEER_PORT=51235
 RIPPLED_HOST=your-rippled-host-url-here
+P2P_RIPPLED_HOST=your-rippled-host-that-can-run-admin-only-requests-url-here
 RIPPLED_SECONDARY=s1.ripple.com,s2.ripple.com,r.ripple.com,rippled.xrptipbot.com
 
 REACT_APP_GA_ID=

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ RIPPLED_WS_PORT=51233
 RIPPLED_RPC_PORT=51234
 RIPPLED_PEER_PORT=51235
 RIPPLED_HOST=your-rippled-host-url-here
-#s1 and s2 are setup to make gateway_balances and account_lines admin only
+#s1 and s2 are set up to make gateway_balances and account_lines admin only
 P2P_RIPPLED_HOST=your-rippled-host-that-can-run-gateway_balances-url-here
 RIPPLED_SECONDARY=s1.ripple.com,s2.ripple.com,r.ripple.com,rippled.xrptipbot.com
 

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ RIPPLED_WS_PORT=51233
 RIPPLED_RPC_PORT=51234
 RIPPLED_PEER_PORT=51235
 RIPPLED_HOST=your-rippled-host-url-here
-P2P_RIPPLED_HOST=your-rippled-host-that-can-run-admin-only-requests-url-here
+#s1 and s2 are setup to make gateway_balances and account_lines admin only
+P2P_RIPPLED_HOST=your-rippled-host-that-can-run-gateway_balances-url-here
 RIPPLED_SECONDARY=s1.ripple.com,s2.ripple.com,r.ripple.com,rippled.xrptipbot.com
 
 REACT_APP_GA_ID=

--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -42,22 +42,22 @@ const formatPaychannel = d => ({
   settleDelay: d.SettleDelay,
 });
 
-function executeQuery(url, ...options) {
+const executeQuery = (url, options) => {
   const params = { ...options, headers: { 'X-User': HOSTNAME } };
-  axios.post(url, params).catch(error => {
+  return axios.post(url, params).catch(error => {
     const message = error.response && error.response.data ? error.response.data : error.toString();
     const code = error.response && error.response.status ? error.response.status : 500;
-    throw new utils.Error(`URL: ${URL} - ${message}`, code);
+    throw new utils.Error(`URL: ${url} - ${message}`, code);
   });
-}
-
-// generic RPC query
-const query = options => {
-  return executeQuery(URL, options);
 };
 
+// generic RPC query
+function query(...options) {
+  return executeQuery(URL, ...options);
+}
+
 function adminQuery(...options) {
-  return executeQuery(P2P_URL, options);
+  return executeQuery(P2P_URL, ...options);
 }
 
 // get ledger

--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -56,7 +56,7 @@ function query(...options) {
   return executeQuery(URL, ...options);
 }
 
-function adminQuery(...options) {
+function queryP2P(...options) {
   return executeQuery(P2P_URL, ...options);
 }
 
@@ -225,7 +225,7 @@ module.exports.getAccountPaychannels = async (account, ledger_index = 'validated
 
 // get Token balance summary
 module.exports.getBalances = (account, ledger_index = 'validated') =>
-  adminQuery({
+  queryP2P({
     method: 'gateway_balances',
     params: [{ account, ledger_index }],
   })


### PR DESCRIPTION
## High Level Overview of Change

We'd like to use a reporting mode server for most things, but `gateway_balances` is an admin only command, so this PR adds functionality to add another server for admin commands.

### Context of Change

Part of upgrading the reliability of the nodes the explorer depends on.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

Did not update to TypeScript because I didn't realize that was a goal and have other priorities this week.

## Before / After

* Before all queries were sent to one URL
* Now if you specify a P2P url, it will direct `gateway_balances` to that url (Defaults to the old behavior)

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

Manually building the code with and without the new environment variable and with different RIPPLED_HOSTs.

<!--
## Future Tasks
For future tasks related to PR.
-->
