### PR TITLE
Add sentinel value of 'unused' for P2P_RIPPLED_HOST

### DIFF
--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -7,9 +7,11 @@ const HOSTNAME = os.hostname();
 const URL = `http://${process.env.RIPPLED_HOST}:${process.env.RIPPLED_RPC_PORT}`;
 const URL_HEALTH = `http://${process.env.RIPPLED_HOST}:${process.env.RIPPLED_PEER_PORT}/health`;
 // If there is a separate peer to peer server for admin requests, use it. Otherwise use the default url for everything.
-const P2P_URL = process.env.P2P_RIPPLED_HOST
-  ? `http://${process.env.P2P_RIPPLED_HOST}:${process.env.RIPPLED_RPC_PORT}`
-  : URL;
+// 'unused' is a sentinel value in case you can't explicitly set a P2P_RIPPLED_HOST to empty/null in your deployment.
+const P2P_URL =
+  process.env.P2P_RIPPLED_HOST && process.env.P2P_RIPPLED_HOST !== 'unused'
+    ? `http://${process.env.P2P_RIPPLED_HOST}:${process.env.RIPPLED_RPC_PORT}`
+    : URL;
 
 const N_UNL_INDEX = '2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244';
 


### PR DESCRIPTION
## High Level Overview of Change

Since we can't add empty environment variables in our gitlab deployment, and using yaml `null` variables causes issues as well, we need a sentinel value for "Don't use this variable" for the P2P_RIPPLED_HOST variable.

### Context of Change

Created as a follow up to #49 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

Other tasks are higher priority than updating this file currently. 

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->
* P2P_RIPPLED_HOST with a value of 'unused' now also defaults to using the RIPPLED_HOST value 

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

Manual local testing
Testing in dev deployment environments in conjunction with the environment variable changes.

<!--
## Future Tasks
For future tasks related to PR.
-->
