### PR TITLE
fix: use correct error code for `/top` endpoint

### DIFF
--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -183,7 +183,7 @@ module.exports = async (req, res) => {
       await sleep(1000);
     }
 
-    res.send({
+    return res.status(200).send({
       result: 'success',
       updated: cachedTokensList.time,
       tokens: cachedTokensList.tokens,

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -190,6 +190,6 @@ module.exports = async (req, res) => {
     });
   } catch (error) {
     log.error(error);
-    res.send({ result: 'error', message: 'internal error' });
+    return res.status(error.code || 500).json({ message: error.message });
   }
 };


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

I ran into an issue where when the `/top` endpoint has an error, it still returns a `200` error code (which is "success").

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

I didn't touch any React files.

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. This matches what the other endpoints do.