### PR TITLE
feat: use the info from the sidechain URL to connect to the sidechain

### DIFF
--- a/src/containers/Accounts/AccountHeader/actions.js
+++ b/src/containers/Accounts/AccountHeader/actions.js
@@ -3,7 +3,7 @@ import { getAccountState } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES, BAD_REQUEST } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadAccountState = accountId => dispatch => {
+export const loadAccountState = (accountId, url = null) => dispatch => {
   if (!isValidClassicAddress(accountId) && !isValidXAddress(accountId)) {
     dispatch({
       type: actionTypes.ACCOUNT_STATE_LOAD_FAIL,
@@ -16,7 +16,7 @@ export const loadAccountState = accountId => dispatch => {
   dispatch({
     type: actionTypes.START_LOADING_ACCOUNT_STATE,
   });
-  return getAccountState(accountId)
+  return getAccountState(accountId, url)
     .then(data => {
       dispatch({ type: actionTypes.FINISHED_LOADING_ACCOUNT_STATE });
       dispatch({

--- a/src/containers/Accounts/AccountHeader/actions.js
+++ b/src/containers/Accounts/AccountHeader/actions.js
@@ -3,7 +3,7 @@ import { getAccountState } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES, BAD_REQUEST } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadAccountState = (accountId, url = null) => dispatch => {
+export const loadAccountState = (accountId, url) => dispatch => {
   if (!isValidClassicAddress(accountId) && !isValidXAddress(accountId)) {
     dispatch({
       type: actionTypes.ACCOUNT_STATE_LOAD_FAIL,

--- a/src/containers/Accounts/AccountHeader/index.js
+++ b/src/containers/Accounts/AccountHeader/index.js
@@ -30,12 +30,12 @@ class AccountHeader extends Component {
 
   componentDidMount() {
     const { actions, accountId } = this.props;
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     actions.loadAccountState(accountId, rippledUrl);
   }
 
   componentDidUpdate(prevProps) {
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     const { accountId, actions } = this.props;
 
     if (prevProps.accountId !== accountId) {

--- a/src/containers/Accounts/AccountHeader/index.js
+++ b/src/containers/Accounts/AccountHeader/index.js
@@ -11,6 +11,7 @@ import './balance-selector.css';
 import BalanceSelector from './BalanceSelector';
 import Account from '../../shared/components/Account';
 import { localizeNumber } from '../../shared/utils';
+import UrlContext from '../../shared/urlContext';
 
 const CURRENCY_OPTIONS = {
   style: 'currency',
@@ -25,13 +26,20 @@ class AccountHeader extends Component {
     this.state = {
       showBalanceSelector: false,
     };
-    props.actions.loadAccountState(props.accountId);
+  }
+
+  componentDidMount() {
+    const { actions, accountId } = this.props;
+    const { rippledUrl } = this.context;
+    actions.loadAccountState(accountId, rippledUrl);
   }
 
   componentDidUpdate(prevProps) {
+    const { rippledUrl } = this.context;
     const { accountId, actions } = this.props;
+
     if (prevProps.accountId !== accountId) {
-      actions.loadAccountState(accountId);
+      actions.loadAccountState(accountId, rippledUrl);
     }
   }
 
@@ -279,6 +287,8 @@ class AccountHeader extends Component {
     );
   }
 }
+
+AccountHeader.contextType = UrlContext;
 
 AccountHeader.propTypes = {
   language: PropTypes.string.isRequired,

--- a/src/containers/Accounts/AccountTransactionsTable/actions.js
+++ b/src/containers/Accounts/AccountTransactionsTable/actions.js
@@ -2,7 +2,7 @@ import { getAccountTransactions } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadAccountTransactions = (accountId, marker, url = null) => dispatch => {
+export const loadAccountTransactions = (accountId, marker, url) => dispatch => {
   dispatch({
     type: actionTypes.START_LOADING_ACCOUNT_TRANSACTIONS,
   });

--- a/src/containers/Accounts/AccountTransactionsTable/actions.js
+++ b/src/containers/Accounts/AccountTransactionsTable/actions.js
@@ -2,11 +2,11 @@ import { getAccountTransactions } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadAccountTransactions = (accountId, marker) => dispatch => {
+export const loadAccountTransactions = (accountId, marker, url = null) => dispatch => {
   dispatch({
     type: actionTypes.START_LOADING_ACCOUNT_TRANSACTIONS,
   });
-  return getAccountTransactions(accountId, undefined, marker, undefined)
+  return getAccountTransactions(accountId, undefined, marker, undefined, url)
     .then(data => {
       dispatch({ type: actionTypes.FINISHED_LOADING_ACCOUNT_TRANSACTIONS });
       dispatch({

--- a/src/containers/Accounts/AccountTransactionsTable/index.js
+++ b/src/containers/Accounts/AccountTransactionsTable/index.js
@@ -30,7 +30,7 @@ export const AccountTxTable = props => {
   const [transactions, setTransactions] = useState([]);
   const [marker, setMarker] = useState(null);
   const { accountId, actions, data, loadingError } = props;
-  const { rippledUrl } = useContext(UrlContext);
+  const rippledUrl = useContext(UrlContext);
 
   useEffect(() => {
     if (data.transactions == null) return;

--- a/src/containers/Accounts/AccountTransactionsTable/index.js
+++ b/src/containers/Accounts/AccountTransactionsTable/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -12,6 +12,7 @@ import Loader from '../../shared/components/Loader';
 import TxDetails from '../../shared/components/TxDetails';
 import './styles.css';
 import TxLabel from '../../shared/components/TxLabel';
+import UrlContext from '../../shared/urlContext';
 
 const TIME_ZONE = 'UTC';
 const DATE_OPTIONS = {
@@ -29,6 +30,7 @@ export const AccountTxTable = props => {
   const [transactions, setTransactions] = useState([]);
   const [marker, setMarker] = useState(null);
   const { accountId, actions, data, loadingError } = props;
+  const { rippledUrl } = useContext(UrlContext);
 
   useEffect(() => {
     if (data.transactions == null) return;
@@ -39,11 +41,11 @@ export const AccountTxTable = props => {
   }, [data]);
 
   useEffect(() => {
-    actions.loadAccountTransactions(accountId);
-  }, [accountId, actions]);
+    actions.loadAccountTransactions(accountId, undefined, rippledUrl);
+  }, [accountId, actions, rippledUrl]);
 
   const loadMoreTransactions = () => {
-    actions.loadAccountTransactions(accountId, marker);
+    actions.loadAccountTransactions(accountId, marker, rippledUrl);
   };
 
   const renderListItem = tx => {

--- a/src/containers/Ledger/actions.js
+++ b/src/containers/Ledger/actions.js
@@ -2,7 +2,7 @@ import { analytics, ANALYTIC_TYPES, BAD_REQUEST, DECIMAL_REGEX, HASH_REGEX } fro
 import * as actionTypes from './actionTypes';
 import { getLedger } from '../../rippled';
 
-export const loadLedger = identifier => dispatch => {
+export const loadLedger = (identifier, url = null) => dispatch => {
   if (!DECIMAL_REGEX.test(identifier) && !HASH_REGEX.test(identifier)) {
     dispatch({
       type: actionTypes.LOADING_FULL_LEDGER_FAIL,
@@ -16,7 +16,7 @@ export const loadLedger = identifier => dispatch => {
     data: { id: identifier },
   });
 
-  return getLedger(identifier)
+  return getLedger(identifier, url)
     .then(data => {
       dispatch({ type: actionTypes.FINISH_LOADING_FULL_LEDGER });
       dispatch({ type: actionTypes.LOADING_FULL_LEDGER_SUCCESS, data });

--- a/src/containers/Ledger/actions.js
+++ b/src/containers/Ledger/actions.js
@@ -2,7 +2,7 @@ import { analytics, ANALYTIC_TYPES, BAD_REQUEST, DECIMAL_REGEX, HASH_REGEX } fro
 import * as actionTypes from './actionTypes';
 import { getLedger } from '../../rippled';
 
-export const loadLedger = (identifier, url = null) => dispatch => {
+export const loadLedger = (identifier, url) => dispatch => {
   if (!DECIMAL_REGEX.test(identifier) && !HASH_REGEX.test(identifier)) {
     dispatch({
       type: actionTypes.LOADING_FULL_LEDGER_FAIL,

--- a/src/containers/Ledger/index.js
+++ b/src/containers/Ledger/index.js
@@ -56,7 +56,7 @@ const getErrorMessage = error => ERROR_MESSAGES[error] || ERROR_MESSAGES.default
 class Ledger extends Component {
   componentDidMount() {
     const { t, actions, match, data } = this.props;
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     const { identifier = '' } = match.params;
     document.title = `${t('xrpl_explorer')} | ${t('ledger')} ${identifier}`;
     analytics(ANALYTIC_TYPES.pageview, { title: 'Ledger', path: '/ledgers/:id' });
@@ -68,7 +68,7 @@ class Ledger extends Component {
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { actions, match } = nextProps;
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     const { match: prevMatch } = this.props;
     const { identifier = '' } = match.params;
     const { identifier: prev } = prevMatch.params;

--- a/src/containers/Ledger/index.js
+++ b/src/containers/Ledger/index.js
@@ -23,6 +23,7 @@ import {
 } from '../shared/utils';
 import './ledger.css';
 import TxLabel from '../shared/components/TxLabel';
+import UrlContext from '../shared/urlContext';
 
 const TIME_ZONE = 'UTC';
 const DATE_OPTIONS = {
@@ -55,24 +56,25 @@ const getErrorMessage = error => ERROR_MESSAGES[error] || ERROR_MESSAGES.default
 class Ledger extends Component {
   componentDidMount() {
     const { t, actions, match, data } = this.props;
+    const { rippledUrl } = this.context;
     const { identifier = '' } = match.params;
     document.title = `${t('xrpl_explorer')} | ${t('ledger')} ${identifier}`;
     analytics(ANALYTIC_TYPES.pageview, { title: 'Ledger', path: '/ledgers/:id' });
-
     if (Number(identifier) !== data.ledger_index) {
-      actions.loadLedger(identifier);
+      actions.loadLedger(identifier, rippledUrl);
     }
   }
 
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { actions, match } = nextProps;
+    const { rippledUrl } = this.context;
     const { match: prevMatch } = this.props;
-    const { identifier } = match.params;
+    const { identifier = '' } = match.params;
     const { identifier: prev } = prevMatch.params;
 
     if (identifier !== prev) {
-      actions.loadLedger(identifier);
+      actions.loadLedger(identifier, rippledUrl);
     }
   }
 
@@ -220,6 +222,8 @@ class Ledger extends Component {
     );
   }
 }
+
+Ledger.contextType = UrlContext;
 
 Ledger.propTypes = {
   t: PropTypes.func.isRequired,

--- a/src/containers/Token/TokenHeader/actions.js
+++ b/src/containers/Token/TokenHeader/actions.js
@@ -3,7 +3,7 @@ import { getToken } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES, BAD_REQUEST } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadTokenState = (currency, accountId) => dispatch => {
+export const loadTokenState = (currency, accountId, url = null) => dispatch => {
   if (!isValidClassicAddress(accountId) && !isValidXAddress(accountId)) {
     dispatch({
       type: actionTypes.ACCOUNT_STATE_LOAD_FAIL,
@@ -16,7 +16,7 @@ export const loadTokenState = (currency, accountId) => dispatch => {
   dispatch({
     type: actionTypes.START_LOADING_ACCOUNT_STATE,
   });
-  return getToken(currency, accountId)
+  return getToken(currency, accountId, url)
     .then(data => {
       dispatch({ type: actionTypes.FINISHED_LOADING_ACCOUNT_STATE });
       dispatch({

--- a/src/containers/Token/TokenHeader/actions.js
+++ b/src/containers/Token/TokenHeader/actions.js
@@ -3,7 +3,7 @@ import { getToken } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES, BAD_REQUEST } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadTokenState = (currency, accountId, url = null) => dispatch => {
+export const loadTokenState = (currency, accountId, url) => dispatch => {
   if (!isValidClassicAddress(accountId) && !isValidXAddress(accountId)) {
     dispatch({
       type: actionTypes.ACCOUNT_STATE_LOAD_FAIL,

--- a/src/containers/Token/TokenHeader/index.js
+++ b/src/containers/Token/TokenHeader/index.js
@@ -30,6 +30,7 @@ class TokenHeader extends Component {
     const nextCurrency = prevProps.currency;
     const { accountId, currency, actions } = this.props;
     const { rippledUrl } = this.context;
+
     if (nextAccountId !== accountId || nextCurrency !== currency) {
       actions.loadTokenState(nextCurrency, nextAccountId, rippledUrl);
     }

--- a/src/containers/Token/TokenHeader/index.js
+++ b/src/containers/Token/TokenHeader/index.js
@@ -9,6 +9,7 @@ import Loader from '../../shared/components/Loader';
 import '../../shared/css/nested-menu.css';
 import './styles.css';
 import { localizeNumber, formatLargeNumber } from '../../shared/utils';
+import UrlContext from '../../shared/urlContext';
 
 const CURRENCY_OPTIONS = {
   style: 'currency',
@@ -18,17 +19,19 @@ const CURRENCY_OPTIONS = {
 };
 
 class TokenHeader extends Component {
-  constructor(props) {
-    super(props);
-    props.actions.loadTokenState(props.currency, props.accountId);
+  componentDidMount() {
+    const { actions, accountId, currency } = this.props;
+    const { rippledUrl } = this.context;
+    actions.loadTokenState(currency, accountId, rippledUrl);
   }
 
   componentDidUpdate(prevProps) {
     const nextAccountId = prevProps.accountId;
     const nextCurrency = prevProps.currency;
     const { accountId, currency, actions } = this.props;
+    const { rippledUrl } = this.context;
     if (nextAccountId !== accountId || nextCurrency !== currency) {
-      actions.loadTokenState(nextCurrency, nextAccountId);
+      actions.loadTokenState(nextCurrency, nextAccountId, rippledUrl);
     }
   }
 
@@ -197,6 +200,8 @@ class TokenHeader extends Component {
     );
   }
 }
+
+TokenHeader.contextType = UrlContext;
 
 TokenHeader.propTypes = {
   language: PropTypes.string.isRequired,

--- a/src/containers/Token/TokenHeader/index.js
+++ b/src/containers/Token/TokenHeader/index.js
@@ -21,7 +21,7 @@ const CURRENCY_OPTIONS = {
 class TokenHeader extends Component {
   componentDidMount() {
     const { actions, accountId, currency } = this.props;
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     actions.loadTokenState(currency, accountId, rippledUrl);
   }
 
@@ -29,7 +29,7 @@ class TokenHeader extends Component {
     const nextAccountId = prevProps.accountId;
     const nextCurrency = prevProps.currency;
     const { accountId, currency, actions } = this.props;
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
 
     if (nextAccountId !== accountId || nextCurrency !== currency) {
       actions.loadTokenState(nextCurrency, nextAccountId, rippledUrl);

--- a/src/containers/Token/TokenTransactionsTable/actions.js
+++ b/src/containers/Token/TokenTransactionsTable/actions.js
@@ -2,11 +2,11 @@ import { getAccountTransactions } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadTokenTransactions = (accountId, currency, marker) => dispatch => {
+export const loadTokenTransactions = (accountId, currency, marker, url = null) => dispatch => {
   dispatch({
     type: actionTypes.START_LOADING_ACCOUNT_TRANSACTIONS,
   });
-  return getAccountTransactions(accountId, currency, marker, undefined)
+  return getAccountTransactions(accountId, currency, marker, undefined, url)
     .then(data => {
       dispatch({ type: actionTypes.FINISHED_LOADING_ACCOUNT_TRANSACTIONS });
       dispatch({

--- a/src/containers/Token/TokenTransactionsTable/actions.js
+++ b/src/containers/Token/TokenTransactionsTable/actions.js
@@ -2,7 +2,7 @@ import { getAccountTransactions } from '../../../rippled';
 import { analytics, ANALYTIC_TYPES } from '../../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadTokenTransactions = (accountId, currency, marker, url = null) => dispatch => {
+export const loadTokenTransactions = (accountId, currency, marker, url) => dispatch => {
   dispatch({
     type: actionTypes.START_LOADING_ACCOUNT_TRANSACTIONS,
   });

--- a/src/containers/Token/TokenTransactionsTable/index.js
+++ b/src/containers/Token/TokenTransactionsTable/index.js
@@ -30,7 +30,7 @@ const DATE_OPTIONS = {
 export const TokenTxTable = props => {
   const [transactions, setTransactions] = useState([]);
   const [marker, setMarker] = useState(null);
-  const { rippledUrl } = useContext(UrlContext);
+  const rippledUrl = useContext(UrlContext);
 
   const { accountId, currency, actions, data, loading, t, loadingError } = props;
 

--- a/src/containers/Token/TokenTransactionsTable/index.js
+++ b/src/containers/Token/TokenTransactionsTable/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
@@ -13,6 +13,7 @@ import '../../Accounts/AccountTransactionsTable/styles.css'; // Reuse AccountTra
 import TxLabel from '../../shared/components/TxLabel';
 
 import { loadTokenTransactions } from './actions';
+import UrlContext from '../../shared/urlContext';
 
 const TIME_ZONE = 'UTC';
 const DATE_OPTIONS = {
@@ -29,6 +30,7 @@ const DATE_OPTIONS = {
 export const TokenTxTable = props => {
   const [transactions, setTransactions] = useState([]);
   const [marker, setMarker] = useState(null);
+  const { rippledUrl } = useContext(UrlContext);
 
   const { accountId, currency, actions, data, loading, t, loadingError } = props;
 
@@ -41,11 +43,11 @@ export const TokenTxTable = props => {
   }, [data]);
 
   useEffect(() => {
-    actions.loadTokenTransactions(accountId, currency);
-  }, [accountId, currency, actions]);
+    actions.loadTokenTransactions(accountId, currency, undefined, rippledUrl);
+  }, [accountId, currency, actions, rippledUrl]);
 
   const loadMoreTransactions = () => {
-    actions.loadTokenTransactions(accountId, marker);
+    actions.loadTokenTransactions(accountId, currency, marker);
   };
 
   const renderListItem = tx => {

--- a/src/containers/Transactions/actions.js
+++ b/src/containers/Transactions/actions.js
@@ -2,7 +2,7 @@ import { getTransaction } from '../../rippled';
 import { analytics, ANALYTIC_TYPES, BAD_REQUEST, HASH_REGEX } from '../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadTransaction = (identifier, url = null) => dispatch => {
+export const loadTransaction = (identifier, url) => dispatch => {
   if (!HASH_REGEX.test(identifier)) {
     dispatch({
       type: actionTypes.LOADING_TRANSACTION_FAIL,

--- a/src/containers/Transactions/actions.js
+++ b/src/containers/Transactions/actions.js
@@ -2,7 +2,7 @@ import { getTransaction } from '../../rippled';
 import { analytics, ANALYTIC_TYPES, BAD_REQUEST, HASH_REGEX } from '../shared/utils';
 import * as actionTypes from './actionTypes';
 
-export const loadTransaction = identifier => dispatch => {
+export const loadTransaction = (identifier, url = null) => dispatch => {
   if (!HASH_REGEX.test(identifier)) {
     dispatch({
       type: actionTypes.LOADING_TRANSACTION_FAIL,
@@ -12,7 +12,7 @@ export const loadTransaction = identifier => dispatch => {
   }
 
   dispatch({ type: actionTypes.START_LOADING_TRANSACTION, data: { id: identifier } });
-  return getTransaction(identifier)
+  return getTransaction(identifier, url)
     .then(data => {
       dispatch({ type: actionTypes.FINISH_LOADING_TRANSACTION });
       dispatch({ type: actionTypes.LOADING_TRANSACTION_SUCCESS, data });

--- a/src/containers/Transactions/index.js
+++ b/src/containers/Transactions/index.js
@@ -15,6 +15,7 @@ import { loadTransaction } from './actions';
 import SimpleTab from './SimpleTab';
 import DetailTab from './DetailTab';
 import './transaction.css';
+import UrlContext from '../shared/urlContext';
 
 const ERROR_MESSAGES = {};
 ERROR_MESSAGES[NOT_FOUND] = {
@@ -37,6 +38,7 @@ class Transaction extends Component {
     const { t, actions, match, data } = this.props;
     const hash = data.raw ? data.raw.hash : undefined;
     const { identifier = '', tab = 'simple' } = match.params;
+    const { rippledUrl } = this.context;
     const short = identifier.substr(0, 8);
 
     document.title = `${t('xrpl_explorer')} | ${t('transaction_short')} ${short}...`;
@@ -46,7 +48,7 @@ class Transaction extends Component {
     });
 
     if (identifier && identifier !== hash) {
-      actions.loadTransaction(identifier);
+      actions.loadTransaction(identifier, rippledUrl);
     }
   }
 
@@ -154,6 +156,8 @@ class Transaction extends Component {
     );
   }
 }
+
+Transaction.contextType = UrlContext;
 
 Transaction.propTypes = {
   t: PropTypes.func.isRequired,

--- a/src/containers/Transactions/index.js
+++ b/src/containers/Transactions/index.js
@@ -38,7 +38,7 @@ class Transaction extends Component {
     const { t, actions, match, data } = this.props;
     const hash = data.raw ? data.raw.hash : undefined;
     const { identifier = '', tab = 'simple' } = match.params;
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     const short = identifier.substr(0, 8);
 
     document.title = `${t('xrpl_explorer')} | ${t('transaction_short')} ${short}...`;
@@ -80,8 +80,8 @@ class Transaction extends Component {
 
   renderTabs() {
     const { match } = this.props;
-    const { tab = 'simple', identifier } = match.params;
-    const { path = '/' } = match;
+    const { path = '/', params } = match;
+    const { tab = 'simple', identifier } = params;
     const tabs = ['simple', 'detailed', 'raw'];
     // strips :url from the front and the identifier/tab info from the end
     const mainPath = `${path.split('/:')[0]}/${identifier}`;

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -271,7 +271,7 @@ class Streams extends Component {
         } else if (streamResult.type === 'ledgerClosed') {
           const { ledger, metrics } = handleLedger(streamResult);
           this.onledger(ledger);
-          fetchLedger(ledger, undefined, rippledUrl)
+          fetchLedger(ledger, rippledUrl)
             .then(ledgerSummary => {
               this.onledgerSummary(ledgerSummary);
             })

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -204,7 +204,7 @@ class Streams extends Component {
   }
 
   updateQuorum() {
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     fetchQuorum(rippledUrl).then(quorum => {
       const { updateMetrics } = this.props;
       this.setState(prevState => {
@@ -217,7 +217,7 @@ class Streams extends Component {
 
   updateNegativeUNL() {
     this.updateQuorum();
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     fetchNegativeUNL(rippledUrl).then(nUnl => {
       const { updateMetrics } = this.props;
       this.setState(prevState => {
@@ -229,7 +229,7 @@ class Streams extends Component {
   }
 
   connect() {
-    const { rippledUrl } = this.context;
+    const rippledUrl = this.context;
     const rippledWsUrl = `wss://${rippledUrl}:${process.env.REACT_APP_RIPPLED_WS_PORT}`;
     this.ws = new WebSocket(rippledUrl == null ? DEFAULT_WS_URL : rippledWsUrl);
     this.ws.last = Date.now();

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -303,8 +303,8 @@ export const durationToHuman = (s, decimal = 2) => {
   return `${d.num.toFixed(decimal)} ${d.unit}`;
 };
 
-export const fetchNegativeUNL = async () => {
-  return getNegativeUNL()
+export const fetchNegativeUNL = async (rippledUrl = null) => {
+  return getNegativeUNL(rippledUrl)
     .then(data => {
       if (data === undefined) throw new Error('undefined nUNL');
 
@@ -313,8 +313,8 @@ export const fetchNegativeUNL = async () => {
     .catch(e => Log.error(e));
 };
 
-export const fetchQuorum = async () => {
-  return getQuorum()
+export const fetchQuorum = async (rippledUrl = null) => {
+  return getQuorum(rippledUrl)
     .then(data => {
       if (data === undefined) throw new Error('undefined quorum');
       return data;

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -303,7 +303,7 @@ export const durationToHuman = (s, decimal = 2) => {
   return `${d.num.toFixed(decimal)} ${d.unit}`;
 };
 
-export const fetchNegativeUNL = async (rippledUrl = null) => {
+export const fetchNegativeUNL = async rippledUrl => {
   return getNegativeUNL(rippledUrl)
     .then(data => {
       if (data === undefined) throw new Error('undefined nUNL');
@@ -313,7 +313,7 @@ export const fetchNegativeUNL = async (rippledUrl = null) => {
     .catch(e => Log.error(e));
 };
 
-export const fetchQuorum = async (rippledUrl = null) => {
+export const fetchQuorum = async rippledUrl => {
   return getQuorum(rippledUrl)
     .then(data => {
       if (data === undefined) throw new Error('undefined quorum');

--- a/src/rippled/accountState.js
+++ b/src/rippled/accountState.js
@@ -45,7 +45,7 @@ const formatResults = (info, data) => {
 
   return balances;
 };
-const getAccountState = account => {
+const getAccountState = (account, url = null) => {
   // TODO: Retrieve balances for untagged X-address only? or display notice/warning
 
   let classicAddress;
@@ -80,13 +80,13 @@ const getAccountState = account => {
   }
 
   log.info(`get balances: ${account} -> ${classicAddress}`);
-  return getAccountInfo(classicAddress)
+  return getAccountInfo(classicAddress, url)
     .then(info =>
       Promise.all([
-        getBalances(classicAddress, info.ledger_index).then(data => formatResults(info, data)),
-        getAccountEscrows(classicAddress, info.ledger_index),
-        getAccountPaychannels(classicAddress, info.ledger_index),
-        getServerInfo(),
+        getBalances(classicAddress, info.ledger_index, url).then(data => formatResults(info, data)),
+        getAccountEscrows(classicAddress, info.ledger_index, url),
+        getAccountPaychannels(classicAddress, info.ledger_index, url),
+        getServerInfo(url),
       ]).then(data => {
         return {
           account: info.Account,

--- a/src/rippled/accountState.js
+++ b/src/rippled/accountState.js
@@ -45,7 +45,7 @@ const formatResults = (info, data) => {
 
   return balances;
 };
-const getAccountState = (account, url = null) => {
+const getAccountState = (account, url) => {
   // TODO: Retrieve balances for untagged X-address only? or display notice/warning
 
   let classicAddress;

--- a/src/rippled/accountState.js
+++ b/src/rippled/accountState.js
@@ -80,12 +80,12 @@ const getAccountState = (account, url = null) => {
   }
 
   log.info(`get balances: ${account} -> ${classicAddress}`);
-  return getAccountInfo(classicAddress, url)
+  return getAccountInfo(url, classicAddress)
     .then(info =>
       Promise.all([
-        getBalances(classicAddress, info.ledger_index, url).then(data => formatResults(info, data)),
-        getAccountEscrows(classicAddress, info.ledger_index, url),
-        getAccountPaychannels(classicAddress, info.ledger_index, url),
+        getBalances(url, classicAddress, info.ledger_index).then(data => formatResults(info, data)),
+        getAccountEscrows(url, classicAddress, info.ledger_index),
+        getAccountPaychannels(url, classicAddress, info.ledger_index),
         getServerInfo(url),
       ]).then(data => {
         return {

--- a/src/rippled/accountTransactions.js
+++ b/src/rippled/accountTransactions.js
@@ -54,7 +54,7 @@ const getAccountTransactions = async (account, currency, marker, limit, url = nu
   }
 
   log.info(`get transactions: ${account} -> ${classicAddress}`);
-  return getAccountTxs(classicAddress, limit, marker, url)
+  return getAccountTxs(url, classicAddress, limit, marker)
     .then(data => {
       const transactions = data.transactions
         .map(tx => {

--- a/src/rippled/accountTransactions.js
+++ b/src/rippled/accountTransactions.js
@@ -19,7 +19,7 @@ import logger from './lib/logger';
 
 const log = logger({ name: 'account transactions' });
 
-const getAccountTransactions = async (account, currency, marker, limit) => {
+const getAccountTransactions = async (account, currency, marker, limit, url = null) => {
   // TODO: Retrieve txs for untagged X-address only?
 
   let classicAddress;
@@ -54,7 +54,7 @@ const getAccountTransactions = async (account, currency, marker, limit) => {
   }
 
   log.info(`get transactions: ${account} -> ${classicAddress}`);
-  return getAccountTxs(classicAddress, limit, marker)
+  return getAccountTxs(classicAddress, limit, marker, url)
     .then(data => {
       const transactions = data.transactions
         .map(tx => {

--- a/src/rippled/accountTransactions.js
+++ b/src/rippled/accountTransactions.js
@@ -19,7 +19,7 @@ import logger from './lib/logger';
 
 const log = logger({ name: 'account transactions' });
 
-const getAccountTransactions = async (account, currency, marker, limit, url = null) => {
+const getAccountTransactions = async (account, currency, marker, limit, url) => {
   // TODO: Retrieve txs for untagged X-address only?
 
   let classicAddress;

--- a/src/rippled/ledgers.js
+++ b/src/rippled/ledgers.js
@@ -4,7 +4,7 @@ import logger from './lib/logger';
 
 const log = logger({ name: 'ledgers' });
 
-const getLedger = identifier => {
+const getLedger = (identifier, url = null) => {
   const parameters = {};
   if (!isNaN(identifier)) {
     parameters.ledger_index = Number(identifier);
@@ -18,8 +18,7 @@ const getLedger = identifier => {
   }
 
   log.info(`get ledger: ${JSON.stringify(parameters)}`);
-
-  return getRippledLedger(parameters)
+  return getRippledLedger(parameters, url)
     .then(ledger => summarizeLedger(ledger, true))
     .then(data => {
       return data;

--- a/src/rippled/ledgers.js
+++ b/src/rippled/ledgers.js
@@ -4,7 +4,7 @@ import logger from './lib/logger';
 
 const log = logger({ name: 'ledgers' });
 
-const getLedger = (identifier, url = null) => {
+const getLedger = (identifier, url) => {
   const parameters = {};
   if (!isNaN(identifier)) {
     parameters.ledger_index = Number(identifier);

--- a/src/rippled/ledgers.js
+++ b/src/rippled/ledgers.js
@@ -18,7 +18,7 @@ const getLedger = (identifier, url = null) => {
   }
 
   log.info(`get ledger: ${JSON.stringify(parameters)}`);
-  return getRippledLedger(parameters, url)
+  return getRippledLedger(url, parameters)
     .then(ledger => summarizeLedger(ledger, true))
     .then(data => {
       return data;

--- a/src/rippled/lib/rippled.js
+++ b/src/rippled/lib/rippled.js
@@ -291,15 +291,18 @@ const getAccountTransactions = (account, limit = 20, marker = '', url = null) =>
     });
 };
 
-const getNegativeUNL = () =>
-  query({
-    method: 'ledger_entry',
-    params: [
-      {
-        index: N_UNL_INDEX,
-      },
-    ],
-  })
+const getNegativeUNL = (url = null) =>
+  query(
+    {
+      method: 'ledger_entry',
+      params: [
+        {
+          index: N_UNL_INDEX,
+        },
+      ],
+    },
+    url
+  )
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error === 'entryNotFound') {

--- a/src/rippled/lib/rippled.js
+++ b/src/rippled/lib/rippled.js
@@ -58,13 +58,13 @@ function queryP2P(options, url = null) {
 }
 
 // get ledger
-const getLedger = parameters => {
+const getLedger = (parameters, url = null) => {
   const request = {
     method: 'ledger',
     params: [{ ...parameters, transactions: true, expand: true }],
   };
 
-  return query(request)
+  return query(request, url)
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error_message === 'ledgerNotFound') {

--- a/src/rippled/lib/rippled.js
+++ b/src/rippled/lib/rippled.js
@@ -116,11 +116,14 @@ const getTransaction = (txHash, url = null) => {
 };
 
 // get account info
-const getAccountInfo = (account, ledger_index = 'validated') =>
-  query({
-    method: 'account_info',
-    params: [{ account, ledger_index, signer_lists: true }],
-  })
+const getAccountInfo = (account, url = null) =>
+  query(
+    {
+      method: 'account_info',
+      params: [{ account, ledger_index: 'validated', signer_lists: true }],
+    },
+    url
+  )
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error === 'actNotFound') {
@@ -137,11 +140,14 @@ const getAccountInfo = (account, ledger_index = 'validated') =>
     });
 
 // get account escrows
-const getAccountEscrows = (account, ledger_index = 'validated') =>
-  query({
-    method: 'account_objects',
-    params: [{ account, ledger_index, type: 'escrow', limit: 400 }],
-  })
+const getAccountEscrows = (account, ledger_index = 'validated', url = null) =>
+  query(
+    {
+      method: 'account_objects',
+      params: [{ account, ledger_index, type: 'escrow', limit: 400 }],
+    },
+    url
+  )
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error === 'actNotFound') {
@@ -176,14 +182,17 @@ const getAccountEscrows = (account, ledger_index = 'validated') =>
     });
 
 // get account paychannels
-const getAccountPaychannels = async (account, ledger_index = 'validated') => {
+const getAccountPaychannels = async (account, ledger_index = 'validated', url = null) => {
   const list = [];
   let remaining = 0;
   const getChannels = marker =>
-    query({
-      method: 'account_objects',
-      params: [{ marker, account, ledger_index, type: 'payment_channel', limit: 400 }],
-    })
+    query(
+      {
+        method: 'account_objects',
+        params: [{ marker, account, ledger_index, type: 'payment_channel', limit: 400 }],
+      },
+      url
+    )
       .then(resp => resp.data.result)
       .then(resp => {
         if (resp.error === 'actNotFound') {
@@ -220,11 +229,14 @@ const getAccountPaychannels = async (account, ledger_index = 'validated') => {
 };
 
 // get Token balance summary
-const getBalances = (account, ledger_index = 'validated') =>
-  queryP2P({
-    method: 'gateway_balances',
-    params: [{ account, ledger_index }],
-  })
+const getBalances = (account, ledger_index = 'validated', url = null) =>
+  queryP2P(
+    {
+      method: 'gateway_balances',
+      params: [{ account, ledger_index }],
+    },
+    url
+  )
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error === 'actNotFound') {
@@ -239,27 +251,30 @@ const getBalances = (account, ledger_index = 'validated') =>
     });
 
 // get account transactions
-const getAccountTransactions = (account, limit = 20, marker = '') => {
+const getAccountTransactions = (account, limit = 20, marker = '', url = null) => {
   const markerComponents = marker.split('.');
   const ledger = parseInt(markerComponents[0], 10);
   const seq = parseInt(markerComponents[1], 10);
-  return query({
-    method: 'account_tx',
-    params: [
-      {
-        account,
-        limit,
-        ledger_index_max: -1,
-        ledger_index_min: -1,
-        marker: marker
-          ? {
-              ledger,
-              seq,
-            }
-          : undefined,
-      },
-    ],
-  })
+  return query(
+    {
+      method: 'account_tx',
+      params: [
+        {
+          account,
+          limit,
+          ledger_index_max: -1,
+          ledger_index_min: -1,
+          marker: marker
+            ? {
+                ledger,
+                seq,
+              }
+            : undefined,
+        },
+      ],
+    },
+    url
+  )
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error === 'actNotFound') {
@@ -298,10 +313,13 @@ const getNegativeUNL = () =>
       return resp;
     });
 
-const getServerInfo = () =>
-  query({
-    method: 'server_info',
-  })
+const getServerInfo = (url = null) =>
+  query(
+    {
+      method: 'server_info',
+    },
+    url
+  )
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error !== undefined || resp.error_message !== undefined) {

--- a/src/rippled/lib/rippled.js
+++ b/src/rippled/lib/rippled.js
@@ -5,6 +5,7 @@ import { Error, XRP_BASE, EPOCH_OFFSET } from './utils';
 
 const HOSTNAME = hostname();
 const N_UNL_INDEX = '2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244';
+const P2P_URL = process.env.REACT_APP_P2P_RIPPLED_HOST ?? process.env.REACT_APP_RIPPLED_HOST;
 
 const formatEscrow = d => ({
   id: d.index,
@@ -46,17 +47,14 @@ const executeQuery = (url, options) => {
 };
 
 // generic RPC query
-function query(...options) {
-  return executeQuery(process.env.REACT_APP_RIPPLED_HOST, ...options);
+function query(options, url = null) {
+  return executeQuery(url ?? process.env.REACT_APP_RIPPLED_HOST, options);
 }
 
 // If there is a separate peer to peer (not reporting mode) server for admin requests, use it.
 // Otherwise use the default url for everything.
-function queryP2P(...options) {
-  return executeQuery(
-    process.env.REACT_APP_P2P_RIPPLED_HOST ?? process.env.REACT_APP_RIPPLED_HOST,
-    ...options
-  );
+function queryP2P(options, url = null) {
+  return executeQuery(url ?? P2P_URL, options);
 }
 
 // get ledger
@@ -89,13 +87,13 @@ const getLedger = parameters => {
 };
 
 // get transaction
-const getTransaction = txHash => {
+const getTransaction = (txHash, url = null) => {
   const params = {
     method: 'tx',
     params: [{ transaction: txHash }],
   };
 
-  return query(params)
+  return query(params, url)
     .then(resp => resp.data.result)
     .then(resp => {
       if (resp.error === 'txnNotFound') {

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -27,8 +27,8 @@ const sleep = ms => {
 };
 
 // fetch full ledger
-const fetchLedger = (ledger, attempts = 0) => {
-  return getLedger({ ledger_hash: ledger.ledger_hash })
+const fetchLedger = (ledger, attempts = 0, rippledUrl = null) => {
+  return getLedger({ ledger_hash: ledger.ledger_hash }, rippledUrl)
     .then(summarizeLedger)
     .then(summary => {
       Object.assign(ledger, summary);
@@ -38,9 +38,9 @@ const fetchLedger = (ledger, attempts = 0) => {
       log.error(error.toString());
       if (error.code === 404 && attempts < 5) {
         log.info(`retry ledger ${ledger.ledger_index} (attempt:${attempts + 1})`);
-        return sleep(500).then(() => fetchLedger(ledger, attempts + 1));
+        setTimeout(fetchLedger, 500, ledger, attempts + 1, rippledUrl);
       }
-      return undefined;
+      throw error;
     });
 };
 

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -38,7 +38,7 @@ const fetchLedger = (ledger, rippledUrl, attempts = 0) => {
       log.error(error.toString());
       if (error.code === 404 && attempts < 5) {
         log.info(`retry ledger ${ledger.ledger_index} (attempt:${attempts + 1})`);
-        setTimeout(fetchLedger, 500, ledger, rippledUrl, attempts + 1);
+        return sleep(500).then(() => fetchLedger(ledger, rippledUrl, attempts + 1));
       }
       throw error;
     });

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -28,7 +28,7 @@ const sleep = ms => {
 
 // fetch full ledger
 const fetchLedger = (ledger, rippledUrl, attempts = 0) => {
-  return getLedger({ ledger_hash: ledger.ledger_hash }, rippledUrl)
+  return getLedger(rippledUrl, { ledger_hash: ledger.ledger_hash })
     .then(summarizeLedger)
     .then(summary => {
       Object.assign(ledger, summary);

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -27,7 +27,7 @@ const sleep = ms => {
 };
 
 // fetch full ledger
-const fetchLedger = (ledger, attempts = 0, rippledUrl = null) => {
+const fetchLedger = (ledger, rippledUrl, attempts = 0) => {
   return getLedger({ ledger_hash: ledger.ledger_hash }, rippledUrl)
     .then(summarizeLedger)
     .then(summary => {
@@ -38,7 +38,7 @@ const fetchLedger = (ledger, attempts = 0, rippledUrl = null) => {
       log.error(error.toString());
       if (error.code === 404 && attempts < 5) {
         log.info(`retry ledger ${ledger.ledger_index} (attempt:${attempts + 1})`);
-        setTimeout(fetchLedger, 500, ledger, attempts + 1, rippledUrl);
+        setTimeout(fetchLedger, 500, ledger, rippledUrl, attempts + 1);
       }
       throw error;
     });

--- a/src/rippled/nUNL.js
+++ b/src/rippled/nUNL.js
@@ -5,10 +5,10 @@ import logger from './lib/logger';
 
 const log = logger({ name: 'nunl' });
 
-const getNegativeUNL = () => {
+const getNegativeUNL = (url = null) => {
   log.info(`getting nUNL from rippled`);
 
-  return getRippledNegativeUNL()
+  return getRippledNegativeUNL(url)
     .then(result => {
       if (result === undefined || result.length === 0) return [];
 

--- a/src/rippled/nUNL.js
+++ b/src/rippled/nUNL.js
@@ -5,7 +5,7 @@ import logger from './lib/logger';
 
 const log = logger({ name: 'nunl' });
 
-const getNegativeUNL = (url = null) => {
+const getNegativeUNL = url => {
   log.info(`getting nUNL from rippled`);
 
   return getRippledNegativeUNL(url)

--- a/src/rippled/offers.js
+++ b/src/rippled/offers.js
@@ -4,10 +4,17 @@ import { getOffers } from './lib/rippled';
 
 const log = logger({ name: 'offers' });
 
-const getBookOffers = async (currencyCode, issuerAddress, pairCurrencyCode, pairIssuerAddress) => {
+const getBookOffers = async (
+  currencyCode,
+  issuerAddress,
+  pairCurrencyCode,
+  pairIssuerAddress,
+  url = null
+) => {
   try {
     // log.info('fetching book offers from rippled');
     let orderBook = await getOffers(
+      url,
       currencyCode,
       issuerAddress,
       pairCurrencyCode,

--- a/src/rippled/quorum.js
+++ b/src/rippled/quorum.js
@@ -4,7 +4,7 @@ import { getServerInfo } from './lib/rippled';
 
 const log = logger({ name: 'serverInfo' });
 
-const getQuorum = (rippledUrl = null) => {
+const getQuorum = rippledUrl => {
   log.info(`fetching server_info from rippled`);
 
   return getServerInfo(rippledUrl)

--- a/src/rippled/quorum.js
+++ b/src/rippled/quorum.js
@@ -4,10 +4,10 @@ import { getServerInfo } from './lib/rippled';
 
 const log = logger({ name: 'serverInfo' });
 
-const getQuorum = () => {
+const getQuorum = (rippledUrl = null) => {
   log.info(`fetching server_info from rippled`);
 
-  return getServerInfo()
+  return getServerInfo(rippledUrl)
     .then(result => {
       if (result === undefined || result.info === undefined) {
         throw Error('Undefined result from getServerInfo()');

--- a/src/rippled/token.js
+++ b/src/rippled/token.js
@@ -11,7 +11,7 @@ const getToken = async (currencyCode, issuer, url = null) => {
     const serverInfo = await getServerInfo(url);
 
     log.info('fetching gateway_balances from rippled');
-    const balances = await getBalances(issuer);
+    const balances = await getBalances(issuer, undefined, url);
     const obligations = balances?.obligations && balances.obligations[currencyCode.toUpperCase()];
     if (!obligations) {
       throw new Error('Currency not issued by account');

--- a/src/rippled/token.js
+++ b/src/rippled/token.js
@@ -4,11 +4,11 @@ import { getBalances, getAccountInfo, getServerInfo } from './lib/rippled';
 
 const log = logger({ name: 'iou' });
 
-const getToken = async (currencyCode, issuer) => {
+const getToken = async (currencyCode, issuer, url = null) => {
   try {
     log.info('fetching account info from rippled');
-    const accountInfo = await getAccountInfo(issuer);
-    const serverInfo = await getServerInfo();
+    const accountInfo = await getAccountInfo(issuer, url);
+    const serverInfo = await getServerInfo(url);
 
     log.info('fetching gateway_balances from rippled');
     const balances = await getBalances(issuer);

--- a/src/rippled/token.js
+++ b/src/rippled/token.js
@@ -7,11 +7,11 @@ const log = logger({ name: 'iou' });
 const getToken = async (currencyCode, issuer, url = null) => {
   try {
     log.info('fetching account info from rippled');
-    const accountInfo = await getAccountInfo(issuer, url);
+    const accountInfo = await getAccountInfo(url, issuer);
     const serverInfo = await getServerInfo(url);
 
     log.info('fetching gateway_balances from rippled');
-    const balances = await getBalances(issuer, undefined, url);
+    const balances = await getBalances(url, issuer);
     const obligations = balances?.obligations && balances.obligations[currencyCode.toUpperCase()];
     if (!obligations) {
       throw new Error('Currency not issued by account');

--- a/src/rippled/token.js
+++ b/src/rippled/token.js
@@ -4,7 +4,7 @@ import { getBalances, getAccountInfo, getServerInfo } from './lib/rippled';
 
 const log = logger({ name: 'iou' });
 
-const getToken = async (currencyCode, issuer, url = null) => {
+const getToken = async (currencyCode, issuer, url) => {
   try {
     log.info('fetching account info from rippled');
     const accountInfo = await getAccountInfo(url, issuer);

--- a/src/rippled/transactions.js
+++ b/src/rippled/transactions.js
@@ -5,7 +5,7 @@ import summarize from './lib/txSummary';
 
 const log = logger({ name: 'transactions' });
 
-const getTransaction = (transactionId, url = null) => {
+const getTransaction = (transactionId, url) => {
   log.info(`get tx: ${transactionId}`);
   return getRippledTransaction(url, transactionId)
     .then(response => {

--- a/src/rippled/transactions.js
+++ b/src/rippled/transactions.js
@@ -5,9 +5,9 @@ import summarize from './lib/txSummary';
 
 const log = logger({ name: 'transactions' });
 
-const getTransaction = transactionId => {
+const getTransaction = (transactionId, url = null) => {
   log.info(`get tx: ${transactionId}`);
-  return getRippledTransaction(transactionId)
+  return getRippledTransaction(transactionId, url)
     .then(response => {
       return formatTransaction(response);
     })

--- a/src/rippled/transactions.js
+++ b/src/rippled/transactions.js
@@ -7,7 +7,7 @@ const log = logger({ name: 'transactions' });
 
 const getTransaction = (transactionId, url = null) => {
   log.info(`get tx: ${transactionId}`);
-  return getRippledTransaction(transactionId, url)
+  return getRippledTransaction(url, transactionId)
     .then(response => {
       return formatTransaction(response);
     })


### PR DESCRIPTION
## High Level Overview of Change

This PR builds upon #48 to actually use the rippled URL in the Explorer URL to connect. If you go to `[explorer-url.net]/[rippled-url.net]` in sidechain mode, it will use the rippled URL as the node to connect to.

Note: this currently only works for nodes with the standard JSON and WS port configurations (51234 and 51233 respectively), and will not work with reporting mode (because that has `gateway_balances` disabled).

This code is also backwards compatible, so it works for the other network setups (mainnet/testnet/devnet) as well.

This branch is currently deployed to the dev env (https://sidechain.dev.explorer.xpring.dev) if you want to play with it.

### Context of Change

sidechain explorer work

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### TypeScript/Hooks Update

Not worth here

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

No visible changes.

## Test Plan

CI passes (except for the branch threshold). Tested in the dev environment and it worked as expected.
