### PR TITLE
fix: remove server stream

### DIFF
--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -5,7 +5,6 @@ import { fetchNegativeUNL, fetchQuorum, fetchMetrics } from '../utils';
 import {
   handleValidation,
   handleLedger,
-  handleLoadFee,
   fetchLedger,
   fetchServerInfo,
 } from '../../../rippled/lib/streams';
@@ -243,7 +242,7 @@ class Streams extends Component {
       this.ws.send(
         JSON.stringify({
           command: 'subscribe',
-          streams: ['ledger', 'validations', 'server'],
+          streams: ['ledger', 'validations'],
         })
       );
     };
@@ -273,8 +272,8 @@ class Streams extends Component {
             });
           // update the load fee
           fetchServerInfo()
-            .then(metrics => {
-              this.onmetric(metrics);
+            .then(loadFee => {
+              this.onmetric(loadFee);
             })
             .catch(e => {
               Log.error('Ledger fetch error', e.message);
@@ -284,9 +283,6 @@ class Streams extends Component {
           // using `this.onmetric(metrics);`
           // because there is no backend server connection (since there is no one network)
           this.updateMetrics();
-        } else if (streamResult.type === 'serverStatus') {
-          const data = handleLoadFee(streamResult);
-          this.onmetric(data);
         }
       } catch (e) {
         Log.error('message parse error', message);

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -7,6 +7,7 @@ import {
   handleLedger,
   handleLoadFee,
   fetchLedger,
+  fetchServerInfo,
 } from '../../../rippled/lib/streams';
 
 const MAX_LEDGER_COUNT = 20;
@@ -265,6 +266,15 @@ class Streams extends Component {
           fetchLedger(ledger)
             .then(ledgerSummary => {
               this.onledgerSummary(ledgerSummary);
+            })
+            .catch(e => {
+              Log.error('Ledger fetch error', e.message);
+              Log.error(e);
+            });
+          // update the load fee
+          fetchServerInfo()
+            .then(metrics => {
+              this.onmetric(metrics);
             })
             .catch(e => {
               Log.error('Ledger fetch error', e.message);

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -6,7 +6,7 @@ import {
   handleValidation,
   handleLedger,
   fetchLedger,
-  fetchServerInfo,
+  fetchLoadFee,
 } from '../../../rippled/lib/streams';
 
 const MAX_LEDGER_COUNT = 20;
@@ -271,7 +271,7 @@ class Streams extends Component {
               Log.error(e);
             });
           // update the load fee
-          fetchServerInfo()
+          fetchLoadFee()
             .then(loadFee => {
               this.onmetric(loadFee);
             })

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -1,4 +1,4 @@
-import { getLedger } from './rippled';
+import { getLedger, getServerInfo } from './rippled';
 import { summarizeLedger, EPOCH_OFFSET } from './utils';
 import logger from './logger';
 
@@ -41,6 +41,22 @@ const fetchLedger = (ledger, attempts = 0) => {
         return sleep(500).then(() => fetchLedger(ledger, attempts + 1));
       }
       throw error;
+    });
+};
+
+// handle load fee messages
+const handleLoadFee = data => {
+  const loadFee = (data.base_fee * data.load_factor) / data.load_factor_fee_reference / 1000000;
+  return { load_fee: Number(loadFee.toPrecision(4)).toString() };
+};
+
+const fetchServerInfo = () => {
+  return getServerInfo()
+    .then(result => result.info)
+    .then(info => {
+      const ledgerFeeInfo = info.validated_ledger;
+      const loadFee = ledgerFeeInfo.base_fee_xrp * (info.load_factor ?? 1);
+      return { load_fee: Number(loadFee.toPrecision(4)).toString() };
     });
 };
 
@@ -166,12 +182,6 @@ function handleValidation(data) {
   return undefined;
 }
 
-// handle load fee messages
-const handleLoadFee = data => {
-  const loadFee = (data.base_fee * data.load_factor) / data.load_factor_fee_reference / 1000000;
-  return { load_fee: Number(loadFee.toPrecision(4)).toString() };
-};
-
 setInterval(purge, PURGE_INTERVAL);
 
-export { handleLedger, handleValidation, handleLoadFee, fetchLedger };
+export { handleLedger, handleValidation, handleLoadFee, fetchLedger, fetchServerInfo };

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -44,7 +44,7 @@ const fetchLedger = (ledger, attempts = 0) => {
     });
 };
 
-const fetchServerInfo = () => {
+const fetchLoadFee = () => {
   return getServerInfo()
     .then(result => result.info)
     .then(info => {
@@ -178,4 +178,4 @@ function handleValidation(data) {
 
 setInterval(purge, PURGE_INTERVAL);
 
-export { handleLedger, handleValidation, fetchLedger, fetchServerInfo };
+export { handleLedger, handleValidation, fetchLedger, fetchLoadFee };

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -44,12 +44,6 @@ const fetchLedger = (ledger, attempts = 0) => {
     });
 };
 
-// handle load fee messages
-const handleLoadFee = data => {
-  const loadFee = (data.base_fee * data.load_factor) / data.load_factor_fee_reference / 1000000;
-  return { load_fee: Number(loadFee.toPrecision(4)).toString() };
-};
-
 const fetchServerInfo = () => {
   return getServerInfo()
     .then(result => result.info)
@@ -184,4 +178,4 @@ function handleValidation(data) {
 
 setInterval(purge, PURGE_INTERVAL);
 
-export { handleLedger, handleValidation, handleLoadFee, fetchLedger, fetchServerInfo };
+export { handleLedger, handleValidation, fetchLedger, fetchServerInfo };


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the `server` stream from the WS connection. The `server` stream is not supported by reporting mode. It was being used to figure out the load fee metric, so that calculation is redone with a call to `server_info` instead.

### Context of Change

The `server` stream is not supported by reporting mode. This meant that sometimes, when connecting to s2 via WS, we would run into issues 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Tested by hand. Worked successfully.
