### PR TITLE
chore: add "coming soon" placeholder on network page for other networks

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -136,6 +136,8 @@
   "transaction_SetFee": "Set Fee",
   "generic_error": "Something bad happened",
   "not_your_fault": "It's probably not your fault",
+  "under_construction": "This page doesn't exist right now",
+  "come_back_later": "It will be available soon",
   "invalid_ledger_id": "The ledger id is invalid",
   "invalid_transaction_hash": "The transaction hash is invalid",
   "ledger_not_found": "Ledger not Found",

--- a/src/containers/Network/index.js
+++ b/src/containers/Network/index.js
@@ -5,6 +5,7 @@ import Validators from './Validators';
 import Nodes from './Nodes';
 import { analytics, ANALYTIC_TYPES } from '../shared/utils';
 import './css/style.css';
+import NoMatch from '../NoMatch';
 
 class Network extends Component {
   componentDidMount() {
@@ -17,11 +18,23 @@ class Network extends Component {
     });
   }
 
+  renderUnderConstruction = () => {
+    return (
+      <div className="network-page">
+        <NoMatch title="under_construction" hints={['come_back_later']} />
+      </div>
+    );
+  };
+
   render() {
     const { match } = this.props;
     const { params, path } = match;
     const { tab = 'nodes' } = params;
     const base = path.split('/:')[0];
+    const mode = process.env.REACT_APP_ENVIRONMENT;
+    if (mode === 'nft_sandbox' || mode === 'sidechain') {
+      return this.renderUnderConstruction();
+    }
     return tab === 'nodes' ? <Nodes path={base} /> : <Validators path={base} />;
   }
 }

--- a/src/containers/Network/index.js
+++ b/src/containers/Network/index.js
@@ -21,7 +21,7 @@ class Network extends Component {
   renderUnderConstruction = () => {
     return (
       <div className="network-page">
-        <NoMatch title="under_construction" hints={['come_back_later']} />
+        <NoMatch title="under_construction" hints={['come_back_later']} isError={false} />
       </div>
     );
   };

--- a/src/containers/NoMatch/index.js
+++ b/src/containers/NoMatch/index.js
@@ -13,7 +13,7 @@ class NoMatch extends Component {
   }
 
   render() {
-    const { t, title, hints } = this.props;
+    const { t, title, hints, isError = true } = this.props;
     const notFound = title.includes('not_found');
     const hintMsg = hints.map(hint => (
       <div className="hint" key={hint}>
@@ -23,7 +23,7 @@ class NoMatch extends Component {
 
     return (
       <div className="no-match">
-        <div className="uh-oh">{t('404_uh_oh')}</div>
+        {isError && <div className="uh-oh">{t('404_uh_oh')}</div>}
         <div className="title">{t(title)}</div>
         {hintMsg}
         <div className="warning">
@@ -39,11 +39,13 @@ NoMatch.propTypes = {
   t: PropTypes.func.isRequired,
   title: PropTypes.string,
   hints: PropTypes.arrayOf(PropTypes.string),
+  isError: PropTypes.bool,
 };
 
 NoMatch.defaultProps = {
   title: '404_default_title',
   hints: ['404_check_url'],
+  isError: true,
 };
 
 export default translate()(NoMatch);


### PR DESCRIPTION
## High Level Overview of Change

The "networks" page doesn't exist yet for networks that aren't mainnet/devnet/testnet (e.g. sidechains and the NFT-Devnet. So instead of displaying info there that doesn't mean anything/could be misleading, this PR displays a generic error message telling people that the page isn't ready yet.

### Context of Change

The VHS doesn't yet have support for networks that aren't mainnet/devnet/testnet (e.g. sidechains and the NFT-Devnet).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

![image](https://user-images.githubusercontent.com/8029314/154546456-13cffd62-605c-46d6-a92f-b335806900a6.png)

## Test Plan

CI passes. Tested locally and it worked as expected.
