### PR TITLE
feat: Add page for sidechain Explorer if no network chosen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@types/react": "^17.0.15",
         "@types/react-dom": "^17.0.9",
         "@types/react-i18next": "^8.1.0",
+        "@types/react-redux": "^7.1.22",
         "@types/react-router-dom": "^5.1.8",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.28.5",
@@ -4675,6 +4676,16 @@
       "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==",
       "dev": true
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "5.1.1",
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
@@ -4799,6 +4810,27 @@
       "dev": true,
       "dependencies": {
         "react-i18next": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.22",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
+      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/react-router": {
@@ -34385,6 +34417,16 @@
       "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==",
       "dev": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.1",
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
@@ -34507,6 +34549,29 @@
       "dev": true,
       "requires": {
         "react-i18next": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.22",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
+      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+          "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "@types/react-router": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
     "@types/react-i18next": "^8.1.0",
+    "@types/react-redux": "^7.1.22",
     "@types/react-router-dom": "^5.1.8",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.28.5",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -330,6 +330,8 @@
   "issuer":"Issuer",
   "pair":"Pair",
   "offer_range":"Offer Range",
-  "sidechain_node_input": "Type in URL of sidechain node",
+  "sidechain_custom_network": "Sidechain Custom Network",
+  "sidechain_network_input_help": "Enter sidechain network URL to access sidechain data.",
+  "sidechain_network_input": "Type in URL of sidechain network",
   "no_network_selected": "No Sidechain Network Selected"
 }

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -329,5 +329,6 @@
   "obligations_message": "Obligations are the total amounts of each token issued to addresses",
   "issuer":"Issuer",
   "pair":"Pair",
-  "offer_range":"Offer Range"
+  "offer_range":"Offer Range",
+  "sidechain_node_input": "Type in URL of sidechain node"
 }

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -333,5 +333,6 @@
   "sidechain_custom_network": "Sidechain Custom Network",
   "sidechain_network_input_help": "Enter sidechain network URL to access sidechain data.",
   "sidechain_network_input": "Type in URL of sidechain network",
+  "sidechain_networks": "Sidechain Networks",
   "no_network_selected": "No Sidechain Network Selected"
 }

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -330,5 +330,6 @@
   "issuer":"Issuer",
   "pair":"Pair",
   "offer_range":"Offer Range",
-  "sidechain_node_input": "Type in URL of sidechain node"
+  "sidechain_node_input": "Type in URL of sidechain node",
+  "no_network_selected": "No Sidechain Network Selected"
 }

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -11,6 +11,7 @@ import Banner from '../Header/Banner'; // included here for spacing
 import './app.css';
 import App from './App';
 import NoMatch from '../NoMatch';
+import SidechainHome from '../SidechainHome';
 
 const AppWrapper = props => {
   const { t } = props;
@@ -25,6 +26,7 @@ const AppWrapper = props => {
       <Banner />
       <Switch>
         <Route path={path} component={App} />
+        {mode === 'sidechain' && <Route path="/" component={SidechainHome} />}
         <Route component={NoMatch} />
       </Switch>
       <Footer />

--- a/src/containers/Header/Menu.jsx
+++ b/src/containers/Header/Menu.jsx
@@ -116,11 +116,12 @@ Menu.propTypes = {
   t: PropTypes.func.isRequired,
   currentPath: PropTypes.string.isRequired,
   routes: PropTypes.arrayOf(PropTypes.shape({})),
-  inNetwork: PropTypes.bool.isRequired,
+  inNetwork: PropTypes.bool,
 };
 
 Menu.defaultProps = {
   routes: defaultRoutes,
+  inNetwork: true,
 };
 
 export default Menu;

--- a/src/containers/Header/Menu.jsx
+++ b/src/containers/Header/Menu.jsx
@@ -87,9 +87,14 @@ class Menu extends Component {
 
   render() {
     let { routes } = this.props;
+    const { inNetwork } = this.props;
 
     if (MODE !== 'mainnet') {
       routes = removeRoutes(routes, 'tokens');
+    }
+
+    if (!inNetwork) {
+      routes = removeRoutes(routes, 'explorer', 'network', 'tokens');
     }
 
     const menu = routes.map(route => {
@@ -111,6 +116,7 @@ Menu.propTypes = {
   t: PropTypes.func.isRequired,
   currentPath: PropTypes.string.isRequired,
   routes: PropTypes.arrayOf(PropTypes.shape({})),
+  inNetwork: PropTypes.bool.isRequired,
 };
 
 Menu.defaultProps = {

--- a/src/containers/Header/MobileMenu.jsx
+++ b/src/containers/Header/MobileMenu.jsx
@@ -90,6 +90,7 @@ class MobileMenu extends Component {
   render() {
     const { handleEvents } = this;
     let { routes } = this.props;
+    const { inNetwork } = this.props;
     const { isOpen } = this.state;
     const img = isOpen ? closeIcon : unionIcon;
     const style = { display: isOpen ? 'block' : 'none' };
@@ -97,6 +98,9 @@ class MobileMenu extends Component {
 
     if (MODE !== 'mainnet') {
       routes = removeRoutes(routes, 'tokens');
+    }
+    if (!inNetwork) {
+      routes = removeRoutes(routes, 'explorer', 'network', 'tokens');
     }
 
     routes.forEach(route => {
@@ -138,6 +142,7 @@ MobileMenu.propTypes = {
   currentPath: PropTypes.string.isRequired,
   width: PropTypes.number.isRequired,
   routes: PropTypes.arrayOf(PropTypes.shape({})),
+  inNetwork: PropTypes.bool.isRequired,
 };
 
 MobileMenu.defaultProps = {

--- a/src/containers/Header/MobileMenu.jsx
+++ b/src/containers/Header/MobileMenu.jsx
@@ -129,7 +129,7 @@ class MobileMenu extends Component {
           <img src={img} alt="" />
         </div>
         <div className="mobile-menu-items" style={style}>
-          <Search mobile callback={this.closeMenu} />
+          {inNetwork && <Search mobile callback={this.closeMenu} />}
           {items}
         </div>
       </div>

--- a/src/containers/Header/MobileMenu.jsx
+++ b/src/containers/Header/MobileMenu.jsx
@@ -142,11 +142,12 @@ MobileMenu.propTypes = {
   currentPath: PropTypes.string.isRequired,
   width: PropTypes.number.isRequired,
   routes: PropTypes.arrayOf(PropTypes.shape({})),
-  inNetwork: PropTypes.bool.isRequired,
+  inNetwork: PropTypes.bool,
 };
 
 MobileMenu.defaultProps = {
   routes: defaultRoutes,
+  inNetwork: true,
 };
 
 export default connect(state => ({

--- a/src/containers/Header/header.scss
+++ b/src/containers/Header/header.scss
@@ -236,6 +236,10 @@
       flex: 1;
       align-content: center;
       justify-content: center;
+
+      &.notInNetwork {
+        flex: none;
+      }
     }
   }
   .element:first-child {

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -64,6 +64,10 @@ class Header extends Component {
   };
 
   handleCustomNetworkClick = event => {
+    const { expanded } = this.state;
+    if (!expanded) {
+      return;
+    }
     const currentRippledUrl = this.context; // this is undefined if not in sidechain mode
     const newRippledUrl = event.currentTarget.getAttribute('value');
 

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -145,14 +145,16 @@ class Header extends Component {
   }
 
   render() {
-    const { t, isScrolled, width } = this.props;
+    const { t, isScrolled, width, inNetwork } = this.props;
     const { expanded } = this.state;
     const rippledUrl = this.context;
     const menu =
-      width >= BREAKPOINTS.landscape ? <Menu t={t} currentPath={this.getCurrentPath()} /> : null;
+      width >= BREAKPOINTS.landscape ? (
+        <Menu t={t} currentPath={this.getCurrentPath()} inNetwork={inNetwork} />
+      ) : null;
     const mobileMenu =
       width < BREAKPOINTS.landscape ? (
-        <MobileMenu t={t} currentPath={this.getCurrentPath()} />
+        <MobileMenu t={t} currentPath={this.getCurrentPath()} inNetwork={inNetwork} />
       ) : null;
     const currentMode = process.env.REACT_APP_ENVIRONMENT;
 
@@ -212,10 +214,12 @@ class Header extends Component {
                 <Logo className="logo" alt={t('xrpl_explorer')} />
               </Link>
             </div>
-            <div className="element">
-              <Search />
-            </div>
-            <div className="element">{menu}</div>
+            {inNetwork && (
+              <div className="element">
+                <Search />
+              </div>
+            )}
+            <div className={classnames('element', { notInNetwork: !inNetwork })}>{menu}</div>
             {mobileMenu}
           </div>
 
@@ -227,6 +231,10 @@ class Header extends Component {
 }
 Header.contextType = UrlContext;
 
+Header.defaultProps = {
+  inNetwork: true,
+};
+
 Header.propTypes = {
   t: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
@@ -234,6 +242,7 @@ Header.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,
+  inNetwork: PropTypes.bool,
 };
 
 export default withRouter(

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -16,8 +16,6 @@ import { ReactComponent as CheckIcon } from '../shared/images/checkmark.svg';
 import './header.css';
 import UrlContext from '../shared/urlContext';
 
-const MODE = process.env.REACT_APP_ENVIRONMENT;
-
 const STATIC_ENV_LINKS = {
   mainnet: process.env.REACT_APP_MAINNET_LINK,
   testnet: process.env.REACT_APP_TESTNET_LINK,

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -151,11 +151,11 @@ class Header extends Component {
     const { expanded } = this.state;
     const rippledUrl = this.context;
     const menu =
-      width >= BREAKPOINTS.landscape ? (
+      width >= BREAKPOINTS.landscape || !inNetwork ? (
         <Menu t={t} currentPath={this.getCurrentPath()} inNetwork={inNetwork} />
       ) : null;
     const mobileMenu =
-      width < BREAKPOINTS.landscape ? (
+      width < BREAKPOINTS.landscape && inNetwork ? (
         <MobileMenu t={t} currentPath={this.getCurrentPath()} inNetwork={inNetwork} />
       ) : null;
     const currentMode = process.env.REACT_APP_ENVIRONMENT;

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -177,6 +177,14 @@ class Header extends Component {
               onKeyUp={this.toggleExpand}
             >
               <div className="bg" />
+              {!inNetwork &&
+                !expanded &&
+                this.renderDropdown(
+                  'no-network',
+                  this.handleCustomNetworkClick,
+                  classnames('item', 'custom', { selected: true }),
+                  t('no_network_selected')
+                )}
               {Object.keys(urlLinkMap).map(network => {
                 return isCustomNetwork(network)
                   ? this.renderDropdown(

--- a/src/containers/Header/test/Header.test.js
+++ b/src/containers/Header/test/Header.test.js
@@ -56,7 +56,6 @@ describe('Header component', () => {
 
     beforeEach(() => {
       delete window.location;
-      // mockedFunction = jest.fn();
       window.location = { assign: mockedFunction };
       process.env = { ...oldEnvs, REACT_APP_ENVIRONMENT: 'mainnet' };
     });

--- a/src/containers/SidechainHome/index.scss
+++ b/src/containers/SidechainHome/index.scss
@@ -14,7 +14,7 @@
       align-items: center;
       justify-content: center;
       padding: auto;
-      margin: 97px auto 80px;
+      margin: 97px auto 80px auto;
       text-align: center;
 
       .sidechain-logo {
@@ -27,7 +27,7 @@
       }
 
       .page-header {
-        margin: 0px 24px;
+        margin: 0 24px;
         font-size: 20px;
         @include bold;
 
@@ -41,7 +41,7 @@
       }
 
       .input-help {
-        margin: 16px 0px;
+        margin: 16px 0;
         font-size: 14px;
       }
 
@@ -106,7 +106,7 @@
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-        padding: 24px 0px;
+        padding: 24px 0;
         border-bottom: 1px solid $black-80;
         color: inherit;
         font-size: 16px;

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -56,7 +56,7 @@ const SidechainHome = (props: Props) => {
   }
 
   // TODO: get previous networks from cookies
-  const existingNetworks: string[] = ['s1.ripple.com', 's2.ripple.com'];
+  const existingNetworks: string[] = [];
 
   return (
     <div className="app">
@@ -68,15 +68,20 @@ const SidechainHome = (props: Props) => {
           <div className="text box-header">Sidechain Custom Network</div>
           <div className="text help">Enter sidechain node URL to access sidechain data.</div>
           <input
+            className="sidechain-input"
             type="text"
             placeholder={t('sidechain_node_input')}
             onKeyDown={sidechainOnKeyDown}
             ref={networkText}
           />
-          <div className="button">
-            <div tabIndex={0} role="button" onClick={clickButton} onKeyUp={clickButton}>
-              <span>Go to network</span>
-            </div>
+          <div
+            className="button"
+            tabIndex={0}
+            role="button"
+            onClick={clickButton}
+            onKeyUp={clickButton}
+          >
+            <span>Go to network</span>
           </div>
         </div>
         {existingNetworks.length > 0 && (

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+// import PropTypes from 'prop-types';
+// import { Link } from 'react-router-dom';
+import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
+import './sidechainhome.css';
+
+// interface Props {
+
+// }
+
+const SidechainHome = () => {
+  return (
+    <div className="sidechain-main-page">
+      <div className="content">
+        <SidechainLogo className="sidechain-logo" />
+      </div>
+    </div>
+  );
+};
+
+export default SidechainHome;

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -65,12 +65,12 @@ const SidechainHome = (props: Props) => {
       <div className="sidechain-main-page">
         <div className="logo-content">
           <SidechainLogo className="sidechain-logo" />
-          <div className="page-header">Sidechain Custom Network</div>
-          <div className="input-help">Enter sidechain node URL to access sidechain data.</div>
+          <div className="page-header">{t('sidechain_custom_network')}</div>
+          <div className="input-help">{t('sidechain_network_input_help')}</div>
           <input
             className="sidechain-input"
             type="text"
-            placeholder={t('sidechain_node_input')}
+            placeholder={t('sidechain_network_input')}
             onKeyDown={sidechainOnKeyDown}
             ref={networkText}
           />

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -39,8 +39,18 @@ const SidechainHome = (props: Props) => {
   function clickButton(
     _event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>
   ) {
-    switchMode(networkText.current?.value || '');
+    const sidechainUrl = networkText.current?.value;
+    if (sidechainUrl != null) {
+      switchMode(sidechainUrl);
+    }
   }
+
+  function renderCustomNetwork(network: string) {
+    return <div className="custom-network-item">{network}</div>;
+  }
+
+  // TODO: get previous networks from cookies
+  const existingNetworks: string[] = [];
 
   return (
     <div className="app">
@@ -63,6 +73,12 @@ const SidechainHome = (props: Props) => {
             </div>
           </div>
         </div>
+        {existingNetworks.length > 0 && (
+          <div className="custom-network-list">
+            <div className="custom-network-header">Custom Networks</div>
+            {existingNetworks.map(renderCustomNetwork)}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -56,17 +56,17 @@ const SidechainHome = (props: Props) => {
   }
 
   // TODO: get previous networks from cookies
-  const existingNetworks: string[] = [];
+  const existingNetworks: string[] = ['s1.ripple.com', 's2.ripple.com'];
 
   return (
     <div className="app">
       {/* @ts-ignore -- I think this error is because Header isn't in TS */}
       <Header inNetwork={false} />
       <div className="sidechain-main-page">
-        <div className="content">
+        <div className="logo-content">
           <SidechainLogo className="sidechain-logo" />
-          <div className="text box-header">Sidechain Custom Network</div>
-          <div className="text help">Enter sidechain node URL to access sidechain data.</div>
+          <div className="page-header">Sidechain Custom Network</div>
+          <div className="input-help">Enter sidechain node URL to access sidechain data.</div>
           <input
             className="sidechain-input"
             type="text"
@@ -75,7 +75,7 @@ const SidechainHome = (props: Props) => {
             ref={networkText}
           />
           <div
-            className="button"
+            className="sidechain-input-button"
             tabIndex={0}
             role="button"
             onClick={clickButton}

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo
 import Header from '../Header';
 import { ANALYTIC_TYPES, analytics } from '../shared/utils';
 import './sidechainhome.css';
+import { ReactComponent as RightArrow } from '../shared/images/side_arrow_green.svg';
 
 interface Props {
   t: (arg: string) => string;
@@ -46,11 +47,18 @@ const SidechainHome = (props: Props) => {
   }
 
   function renderCustomNetwork(network: string) {
-    return <div className="custom-network-item">{network}</div>;
+    return (
+      <div key={network} className="custom-network-item">
+        <div key={network} className="custom-network-text">
+          {network}
+        </div>
+        <RightArrow className="custom-network-arrow" />
+      </div>
+    );
   }
 
   // TODO: get previous networks from cookies
-  const existingNetworks: string[] = [];
+  const existingNetworks: string[] = ['s1.ripple.com', 's2.ripple.com'];
 
   return (
     <div className="app">

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -5,6 +5,7 @@ import { translate } from 'react-i18next';
 // import PropTypes from 'prop-types';
 // import { Link } from 'react-router-dom';
 import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
+import Header from '../Header';
 import './sidechainhome.css';
 
 interface Props {
@@ -31,24 +32,28 @@ const SidechainHome = (props: Props) => {
   }
 
   return (
-    <div className="sidechain-main-page">
-      <div className="content">
-        <SidechainLogo className="sidechain-logo" />
-        <div className="text box-header">Sidechain Custom Network</div>
-        <div className="text help">Enter sidechain node URL to access sidechain data.</div>
-        <input
-          type="text"
-          placeholder={t('header.search.placeholder')}
-          onKeyDown={sidechainOnKeyDown}
-        />
-        <div
-          tabIndex={0}
-          role="button"
-          className="button"
-          onClick={clickButton}
-          onKeyUp={clickButton}
-        >
-          <span>Go to network</span>
+    <div className="app">
+      {/* @ts-ignore -- I think this error is because Header isn't in TS */}
+      <Header inNetwork={false} />
+      <div className="sidechain-main-page">
+        <div className="content">
+          <SidechainLogo className="sidechain-logo" />
+          <div className="text box-header">Sidechain Custom Network</div>
+          <div className="text help">Enter sidechain node URL to access sidechain data.</div>
+          <input
+            type="text"
+            placeholder="Type in URL of sidechain node"
+            onKeyDown={sidechainOnKeyDown}
+          />
+          <div
+            tabIndex={0}
+            role="button"
+            className="button"
+            onClick={clickButton}
+            onKeyUp={clickButton}
+          >
+            <span>Go to network</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -1,9 +1,7 @@
 import React, { KeyboardEvent, useRef } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
-// import { withRouter } from 'react-router';
-// import PropTypes from 'prop-types';
-// import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
 import Header from '../Header';
 import { ANALYTIC_TYPES, analytics } from '../shared/utils';
@@ -48,12 +46,12 @@ const SidechainHome = (props: Props) => {
 
   function renderCustomNetwork(network: string) {
     return (
-      <div key={network} className="custom-network-item">
+      <Link key={network} className="custom-network-item" to={`/${network}`}>
         <div key={network} className="custom-network-text">
           {network}
         </div>
         <RightArrow className="custom-network-arrow" />
-      </div>
+      </Link>
     );
   }
 

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -1,12 +1,11 @@
 import React, { KeyboardEvent, useRef } from 'react';
-import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
 import Header from '../Header';
 import { ANALYTIC_TYPES, analytics } from '../shared/utils';
-import './sidechainhome.css';
 import { ReactComponent as RightArrow } from '../shared/images/side_arrow_green.svg';
+import './index.css';
 
 interface Props {
   t: (arg: string) => string;
@@ -86,7 +85,7 @@ const SidechainHome = (props: Props) => {
         </div>
         {existingNetworks.length > 0 && (
           <div className="custom-network-list">
-            <div className="custom-network-header">Custom Networks</div>
+            <div className="custom-network-header">{t('sidechain_networks')}</div>
             {existingNetworks.map(renderCustomNetwork)}
           </div>
         )}
@@ -95,7 +94,4 @@ const SidechainHome = (props: Props) => {
   );
 };
 
-export default connect(state => ({
-  // @ts-ignore
-  language: state.app.language,
-}))(translate()(SidechainHome));
+export default translate()(SidechainHome);

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -1,21 +1,61 @@
-import React from 'react';
+import { connect } from 'react-redux';
+import React, { KeyboardEvent } from 'react';
+import { translate } from 'react-i18next';
+// import { withRouter } from 'react-router';
 // import PropTypes from 'prop-types';
 // import { Link } from 'react-router-dom';
 import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
 import './sidechainhome.css';
 
-// interface Props {
+interface Props {
+  t: (arg: string) => string;
+}
 
-// }
+const SidechainHome = (props: Props) => {
+  console.log(props);
+  const { t } = props;
+  console.log(t);
 
-const SidechainHome = () => {
+  function sidechainOnKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      const sidechainUrl = event.currentTarget.value.trim();
+      console.log(sidechainUrl);
+    }
+  }
+
+  function clickButton(
+    event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>
+  ) {
+    console.log(event.target);
+    console.log('button clicked');
+  }
+
   return (
     <div className="sidechain-main-page">
       <div className="content">
         <SidechainLogo className="sidechain-logo" />
+        <div className="text box-header">Sidechain Custom Network</div>
+        <div className="text help">Enter sidechain node URL to access sidechain data.</div>
+        <input
+          type="text"
+          placeholder={t('header.search.placeholder')}
+          onKeyDown={sidechainOnKeyDown}
+        />
+        <div
+          tabIndex={0}
+          role="button"
+          className="button"
+          onClick={clickButton}
+          onKeyUp={clickButton}
+        >
+          <span>Go to network</span>
+        </div>
       </div>
     </div>
   );
 };
 
-export default SidechainHome;
+export default connect(state => ({
+  // @ts-ignore
+  language: state.app.language,
+}))(translate()(SidechainHome));

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useRef } from 'react';
+import React, { KeyboardEvent, useState } from 'react';
 import { translate } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
@@ -14,7 +14,7 @@ interface Props {
 const SidechainHome = (props: Props) => {
   const { t } = props;
 
-  const networkText = useRef<HTMLInputElement>(null);
+  const [networkText, setNetworkText] = useState('');
 
   function switchMode(desiredLink: string) {
     const sidechainUrl = process.env.REACT_APP_SIDECHAIN_LINK;
@@ -28,18 +28,16 @@ const SidechainHome = (props: Props) => {
   }
 
   function sidechainOnKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === 'Enter') {
-      const sidechainUrl = event.currentTarget.value.trim();
-      switchMode(sidechainUrl);
+    if (event.key === 'Enter' && networkText != null) {
+      switchMode(networkText);
     }
   }
 
   function clickButton(
     _event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>
   ) {
-    const sidechainUrl = networkText.current?.value;
-    if (sidechainUrl != null) {
-      switchMode(sidechainUrl);
+    if (networkText != null) {
+      switchMode(networkText);
     }
   }
 
@@ -59,7 +57,7 @@ const SidechainHome = (props: Props) => {
 
   return (
     <div className="app">
-      {/* @ts-ignore -- I think this error is because Header isn't in TS */}
+      {/* @ts-ignore -- TODO: I think this error is because Header isn't in TS */}
       <Header inNetwork={false} />
       <div className="sidechain-main-page">
         <div className="logo-content">
@@ -71,7 +69,8 @@ const SidechainHome = (props: Props) => {
             type="text"
             placeholder={t('sidechain_network_input')}
             onKeyDown={sidechainOnKeyDown}
-            ref={networkText}
+            value={networkText}
+            onChange={event => setNetworkText(event.target.value)}
           />
           <div
             className="sidechain-input-button"

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -56,7 +56,7 @@ const SidechainHome = (props: Props) => {
   }
 
   // TODO: get previous networks from cookies
-  const existingNetworks: string[] = ['s1.ripple.com', 's2.ripple.com'];
+  const existingNetworks: string[] = [];
 
   return (
     <div className="app">

--- a/src/containers/SidechainHome/index.tsx
+++ b/src/containers/SidechainHome/index.tsx
@@ -1,11 +1,12 @@
+import React, { KeyboardEvent, useRef } from 'react';
 import { connect } from 'react-redux';
-import React, { KeyboardEvent } from 'react';
 import { translate } from 'react-i18next';
 // import { withRouter } from 'react-router';
 // import PropTypes from 'prop-types';
 // import { Link } from 'react-router-dom';
 import { ReactComponent as SidechainLogo } from '../shared/images/sidechain_logo.svg';
 import Header from '../Header';
+import { ANALYTIC_TYPES, analytics } from '../shared/utils';
 import './sidechainhome.css';
 
 interface Props {
@@ -13,22 +14,32 @@ interface Props {
 }
 
 const SidechainHome = (props: Props) => {
-  console.log(props);
   const { t } = props;
-  console.log(t);
+
+  const networkText = useRef<HTMLInputElement>(null);
+
+  function switchMode(desiredLink: string) {
+    const sidechainUrl = process.env.REACT_APP_SIDECHAIN_LINK;
+    const url = `${sidechainUrl}/${desiredLink}`;
+    analytics(ANALYTIC_TYPES.event, {
+      eventCategory: 'mode switch',
+      eventAction: url,
+    });
+    // TODO: do some validation on this??
+    window.location.assign(url);
+  }
 
   function sidechainOnKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === 'Enter') {
       const sidechainUrl = event.currentTarget.value.trim();
-      console.log(sidechainUrl);
+      switchMode(sidechainUrl);
     }
   }
 
   function clickButton(
-    event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>
+    _event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>
   ) {
-    console.log(event.target);
-    console.log('button clicked');
+    switchMode(networkText.current?.value || '');
   }
 
   return (
@@ -42,17 +53,14 @@ const SidechainHome = (props: Props) => {
           <div className="text help">Enter sidechain node URL to access sidechain data.</div>
           <input
             type="text"
-            placeholder="Type in URL of sidechain node"
+            placeholder={t('sidechain_node_input')}
             onKeyDown={sidechainOnKeyDown}
+            ref={networkText}
           />
-          <div
-            tabIndex={0}
-            role="button"
-            className="button"
-            onClick={clickButton}
-            onKeyUp={clickButton}
-          >
-            <span>Go to network</span>
+          <div className="button">
+            <div tabIndex={0} role="button" onClick={clickButton} onKeyUp={clickButton}>
+              <span>Go to network</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -1,125 +1,128 @@
 @import '../shared/css/variables.scss';
 
-.sidechain-main-page {
+.app {
   position: relative;
-  min-height: 600px;
+  .sidechain-main-page {
+    position: relative;
+    min-height: 600px;
 
-  // .loader {
-  //   position: absolute;
-  //   z-index: 1;
-  //   top: 0px;
-  //   background: $black;
-  //   opacity: 0;
-  //   pointer-events: none;
-  //   transition: opacity 0.3s ease;
+    // .loader {
+    //   position: absolute;
+    //   z-index: 1;
+    //   top: 0px;
+    //   background: $black;
+    //   opacity: 0;
+    //   pointer-events: none;
+    //   transition: opacity 0.3s ease;
 
-  //   &.show {
-  //     opacity: 0.8;
-  //     transition: opacity 0.15s ease;
-  //   }
-  // }
+    //   &.show {
+    //     opacity: 0.8;
+    //     transition: opacity 0.15s ease;
+    //   }
+    // }
 
-  // a {
-  //   color: inherit;
-  //   text-decoration: none;
-  // }
+    // a {
+    //   color: inherit;
+    //   text-decoration: none;
+    // }
 
-  .content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: auto;
-    margin: 100px auto 0px;
+    .content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: auto;
+      margin: 100px auto 0px;
 
-    .sidechain-logo {
-      width: 400px;
-      height: auto;
-    }
-
-    .box-header {
-      margin: 0px 24px;
-      font-size: 20px;
-      @include bold;
-
-      @include for-size(tablet-landscape-up) {
-        font-size: 24px;
+      .sidechain-logo {
+        width: 400px;
+        height: auto;
       }
 
-      @include for-size(desktop-up) {
-        font-size: 42px;
-      }
-    }
+      .box-header {
+        margin: 0px 24px;
+        font-size: 20px;
+        @include bold;
 
-    .help {
-      margin: 16px 0px;
-      font-size: 14px;
-    }
+        @include for-size(tablet-landscape-up) {
+          font-size: 24px;
+        }
 
-    .text {
-      color: $white;
-      text-align: center;
-    }
-
-    input {
-      width: auto;
-      width: 437px;
-      height: 40px;
-      border: none;
-      margin: 10px 16px;
-      background-color: $gray-900;
-      border-radius: 100px;
-      color: $white;
-      font-size: 16px;
-      line-height: 24px;
-      letter-spacing: 0.01em;
-      padding: 8px 240px 8px 16px;
-
-      &::placeholder {
-        color: $gray-400;
-      }
-
-      @include for-size(desktop-up) {
-        // width: 155px;
-        padding: 8px 40px 8px 25px;
-      }
-
-      @include for-size(big-desktop-up) {
-        // width: 222px;
-        padding: 8px 25px 8px 25px;
-      }
-
-      &:focus {
         @include for-size(desktop-up) {
+          font-size: 42px;
+        }
+      }
+
+      .help {
+        margin: 16px 0px;
+        font-size: 14px;
+      }
+
+      .text {
+        color: $white;
+        text-align: center;
+      }
+
+      input {
+        width: auto;
+        width: 437px;
+        height: 40px;
+        border: none;
+        margin: 10px 16px;
+        background-color: $gray-900;
+        border-radius: 100px;
+        color: $white;
+        font-size: 16px;
+        line-height: 24px;
+        letter-spacing: 0.01em;
+        padding: 8px 240px 8px 16px;
+
+        &::placeholder {
+          color: $gray-400;
+        }
+
+        @include for-size(desktop-up) {
+          // width: 155px;
+          padding: 8px 40px 8px 25px;
+        }
+
+        @include for-size(big-desktop-up) {
           // width: 222px;
           padding: 8px 25px 8px 25px;
         }
+
+        &:focus {
+          @include for-size(desktop-up) {
+            // width: 222px;
+            padding: 8px 25px 8px 25px;
+          }
+        }
       }
-    }
 
-    .button {
-      color: $sidechain;
-      border-radius: 100px;
-      padding: 8px 16px;
-      margin: 16px 16px;
-      font-size: 14px;
-      border: 1px solid $sidechain;
-      box-sizing: border-box;
-    }
+      .button {
+        color: $sidechain;
+        border-radius: 100px;
+        padding: 8px 16px;
+        margin: 16px 16px;
+        font-size: 14px;
+        border: 1px solid $sidechain;
+        box-sizing: border-box;
+      }
 
-    @include for-size(tablet-landscape-up) {
-      width: 552px;
-      padding: 0px 32px 0px 0px;
-    }
+      @include for-size(tablet-landscape-up) {
+        width: 552px;
+        padding: 0px 32px 0px 0px;
+      }
 
-    @include for-size(desktop-up) {
-      width: 772px;
-      padding: 0px 48px 0px 0px;
-    }
+      @include for-size(desktop-up) {
+        width: 772px;
+        padding: 0px 48px 0px 0px;
+      }
 
-    @include for-size(big-desktop-up) {
-      width: 864px;
-      padding: 0px 48px 0px 0px;
+      @include for-size(big-desktop-up) {
+        width: 864px;
+        padding: 0px 48px 0px 0px;
+      }
     }
   }
 }

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -64,18 +64,17 @@
       }
 
       input {
-        width: auto;
         width: 437px;
         height: 40px;
+        padding: 8px 240px 8px 16px;
         border: none;
         margin: 10px 16px;
         background-color: $gray-900;
         border-radius: 100px;
         color: $white;
         font-size: 16px;
-        line-height: 24px;
         letter-spacing: 0.01em;
-        padding: 8px 240px 8px 16px;
+        line-height: 24px;
 
         &::placeholder {
           color: $gray-400;
@@ -100,13 +99,13 @@
       }
 
       .button {
-        color: $sidechain;
-        border-radius: 100px;
-        padding: 8px 16px;
-        margin: 16px 16px;
-        font-size: 14px;
-        border: 1px solid $sidechain;
         box-sizing: border-box;
+        padding: 8px 16px;
+        border: 1px solid $sidechain;
+        margin: 16px 16px;
+        border-radius: 100px;
+        color: $sidechain;
+        font-size: 14px;
       }
 
       @include for-size(tablet-landscape-up) {

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -106,6 +106,13 @@
         border-radius: 100px;
         color: $sidechain;
         font-size: 14px;
+
+        &:hover,
+        &:focus {
+          border: 1px solid $white;
+          color: $white;
+          cursor: pointer;
+        }
       }
 
       @include for-size(tablet-landscape-up) {

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -2,29 +2,10 @@
 
 .app {
   position: relative;
+
   .sidechain-main-page {
     position: relative;
     min-height: 600px;
-
-    // .loader {
-    //   position: absolute;
-    //   z-index: 1;
-    //   top: 0px;
-    //   background: $black;
-    //   opacity: 0;
-    //   pointer-events: none;
-    //   transition: opacity 0.3s ease;
-
-    //   &.show {
-    //     opacity: 0.8;
-    //     transition: opacity 0.15s ease;
-    //   }
-    // }
-
-    // a {
-    //   color: inherit;
-    //   text-decoration: none;
-    // }
 
     .content {
       display: flex;
@@ -32,11 +13,15 @@
       align-items: center;
       justify-content: center;
       padding: auto;
-      margin: 100px auto 100px auto;
+      margin: 97px auto 80px;
 
       .sidechain-logo {
-        width: 400px;
+        width: auto;
         height: auto;
+
+        @include for-size(tablet-landscape-up) {
+          width: 400px;
+        }
       }
 
       .box-header {
@@ -64,9 +49,9 @@
       }
 
       input {
-        width: 437px;
+        width: auto;
         height: 40px;
-        padding: 8px 240px 8px 16px;
+        padding: 8px 25% 8px 16px;
         border: none;
         margin: 10px 16px;
         background-color: $gray-900;
@@ -78,23 +63,6 @@
 
         &::placeholder {
           color: $gray-400;
-        }
-
-        @include for-size(desktop-up) {
-          // width: 155px;
-          padding: 8px 40px 8px 25px;
-        }
-
-        @include for-size(big-desktop-up) {
-          // width: 222px;
-          padding: 8px 25px 8px 25px;
-        }
-
-        &:focus {
-          @include for-size(desktop-up) {
-            // width: 222px;
-            padding: 8px 25px 8px 25px;
-          }
         }
       }
 
@@ -130,6 +98,7 @@
         padding: 0px 48px 0px 0px;
       }
     }
+
     .custom-network-list {
       display: flex;
       flex-direction: column;
@@ -137,12 +106,14 @@
       margin: 0% 10%;
       margin-bottom: 70px;
       color: $white;
-      font-size: 20px;
-      justify-items: right;
+      font-size: 16px;
       text-align: left;
 
       .custom-network-header {
+        padding-bottom: 24px;
         border-bottom: 1px solid $black-80;
+        margin-bottom: 24px;
+        font-size: 20px;
         @include bold;
 
         @include for-size(tablet-landscape-up) {
@@ -151,14 +122,21 @@
       }
 
       .custom-network-item {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 24px 0px;
         border-bottom: 1px solid $black-80;
-        margin: 26px 16px;
-        font-size: 20px;
+        font-size: 16px;
 
         &:hover,
         &:focus {
           color: $sidechain;
           cursor: pointer;
+        }
+
+        .custom-network-arrow {
+          text-align: right;
         }
       }
     }

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -59,6 +59,7 @@
         line-height: 24px;
 
         &::placeholder {
+          overflow: visible;
           color: $gray-400;
         }
       }

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -6,18 +6,16 @@
   .sidechain-main-page {
     position: relative;
     min-height: 600px;
+    color: $white;
 
-    .content {
+    .logo-content {
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
       padding: auto;
       margin: 97px auto 80px;
-
-      @include for-size(tablet-landscape-up) {
-        margin-bottom: 0px;
-      }
+      text-align: center;
 
       .sidechain-logo {
         width: auto;
@@ -28,7 +26,7 @@
         }
       }
 
-      .box-header {
+      .page-header {
         margin: 0px 24px;
         font-size: 20px;
         @include bold;
@@ -42,14 +40,9 @@
         }
       }
 
-      .help {
+      .input-help {
         margin: 16px 0px;
         font-size: 14px;
-      }
-
-      .text {
-        color: $white;
-        text-align: center;
       }
 
       input {
@@ -70,7 +63,7 @@
         }
       }
 
-      .button {
+      .sidechain-input-button {
         box-sizing: border-box;
         padding: 8px 16px;
         border: 1px solid $sidechain;
@@ -94,7 +87,6 @@
       align-items: normal;
       margin: 0% 10%;
       margin-bottom: 70px;
-      color: $white;
       font-size: 16px;
       text-align: left;
 

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -115,7 +115,9 @@
         justify-content: space-between;
         padding: 24px 0px;
         border-bottom: 1px solid $black-80;
+        color: inherit;
         font-size: 16px;
+        text-decoration: none;
 
         &:hover,
         &:focus {

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -15,6 +15,10 @@
       padding: auto;
       margin: 97px auto 80px;
 
+      @include for-size(tablet-landscape-up) {
+        margin-bottom: 0px;
+      }
+
       .sidechain-logo {
         width: auto;
         height: auto;
@@ -81,21 +85,6 @@
           color: $white;
           cursor: pointer;
         }
-      }
-
-      @include for-size(tablet-landscape-up) {
-        width: 552px;
-        padding: 0px 32px 0px 0px;
-      }
-
-      @include for-size(desktop-up) {
-        width: 772px;
-        padding: 0px 48px 0px 0px;
-      }
-
-      @include for-size(big-desktop-up) {
-        width: 864px;
-        padding: 0px 48px 0px 0px;
       }
     }
 

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -1,0 +1,191 @@
+@import '../shared/css/variables.scss';
+
+.sidechain-main-page {
+  position: relative;
+  min-height: 600px;
+
+  // .loader {
+  //   position: absolute;
+  //   z-index: 1;
+  //   top: 0px;
+  //   background: $black;
+  //   opacity: 0;
+  //   pointer-events: none;
+  //   transition: opacity 0.3s ease;
+
+  //   &.show {
+  //     opacity: 0.8;
+  //     transition: opacity 0.15s ease;
+  //   }
+  // }
+
+  // a {
+  //   color: inherit;
+  //   text-decoration: none;
+  // }
+
+  .content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0px 10px;
+    margin: 100px auto 0px;
+
+    .sidechain-logo {
+      width: 400px;
+      height: auto;
+    }
+
+    @include for-size(tablet-landscape-up) {
+      width: 552px;
+      padding: 0px 32px 0px 0px;
+    }
+
+    @include for-size(desktop-up) {
+      width: 772px;
+      padding: 0px 48px 0px 0px;
+    }
+
+    @include for-size(big-desktop-up) {
+      width: 864px;
+      padding: 0px 48px 0px 0px;
+    }
+
+    .tab {
+      padding-top: 24px;
+      padding-bottom: 24px;
+      margin-bottom: -1px;
+    }
+  }
+
+  .summary {
+    width: calc(100% - 32px);
+    padding: 30px 0px 20px;
+    margin: 0px auto;
+
+    @include for-size(tablet-landscape-up) {
+      width: 584px;
+    }
+    @include for-size(desktop-up) {
+      width: 820px;
+    }
+    @include for-size(big-desktop-up) {
+      width: 912px;
+    }
+
+    .type {
+      display: inline-block;
+      padding-bottom: 24px;
+      color: $white;
+      font-size: 42px;
+      @include bold;
+    }
+
+    .label {
+      margin-top: 16px;
+      margin-bottom: 4px;
+      color: $black-80;
+      font-size: 24px;
+      line-height: 32px;
+      @include bold;
+
+      @include for-size(tablet-landscape-up) {
+        font-size: 32px;
+        line-height: 40px;
+      }
+      @include for-size(desktop-up) {
+        font-size: 40px;
+        line-height: 48px;
+      }
+      @include for-size(big-desktop-up) {
+        font-size: 40px;
+        line-height: 48px;
+      }
+    }
+
+    .hash {
+      overflow: hidden;
+      padding-bottom: 87px;
+      color: $gray-400;
+      font-size: 12px;
+      letter-spacing: 0px;
+      line-height: 20px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      @include medium;
+    }
+
+    .status {
+      display: inline-block;
+      padding: 0px 15px 20px;
+      font-size: 10px;
+      line-height: 18px;
+      text-transform: uppercase;
+      vertical-align: middle;
+      @include bold;
+
+      @include for-size(tablet-landscape-up) {
+        font-size: 12px;
+        line-height: 20px;
+      }
+      @include for-size(desktop-up) {
+        font-size: 12px;
+        line-height: 20px;
+      }
+      @include for-size(big-desktop-up) {
+        font-size: 12px;
+        line-height: 20px;
+      }
+
+      &.success {
+        color: $green;
+      }
+
+      &.fail {
+        color: $orange-600;
+
+        span {
+          text-transform: none;
+        }
+      }
+
+      img {
+        position: relative;
+        top: 4px;
+        width: 16px;
+        height: 16px;
+        margin-right: 4px;
+      }
+    }
+  }
+
+  .tab-body {
+    margin: 0px auto;
+
+    @include for-size(tablet-landscape-up) {
+      width: 584px;
+    }
+    @include for-size(desktop-up) {
+      width: 820px;
+    }
+    @include for-size(big-desktop-up) {
+      width: 912px;
+    }
+
+    .react-json-view {
+      overflow: hidden;
+      margin-bottom: 40px;
+      font-size: 12px;
+      letter-spacing: 0px;
+
+      .variable-row,
+      .object-key-val {
+        padding: 1px 5px 1px 15px !important;
+      }
+
+      .copy-icon svg {
+        height: 14px !important;
+      }
+    }
+  }
+}

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -26,14 +26,85 @@
 
   .content {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 0px 10px;
+    padding: auto;
     margin: 100px auto 0px;
 
     .sidechain-logo {
       width: 400px;
       height: auto;
+    }
+
+    .box-header {
+      margin: 0px 24px;
+      font-size: 20px;
+      @include bold;
+
+      @include for-size(tablet-landscape-up) {
+        font-size: 24px;
+      }
+
+      @include for-size(desktop-up) {
+        font-size: 42px;
+      }
+    }
+
+    .help {
+      margin: 16px 0px;
+      font-size: 14px;
+    }
+
+    .text {
+      color: $white;
+      text-align: center;
+    }
+
+    input {
+      width: auto;
+      width: 437px;
+      height: 40px;
+      border: none;
+      margin: 10px 16px;
+      background-color: $gray-900;
+      border-radius: 100px;
+      color: $white;
+      font-size: 16px;
+      line-height: 24px;
+      letter-spacing: 0.01em;
+      padding: 8px 240px 8px 16px;
+
+      &::placeholder {
+        color: $gray-400;
+      }
+
+      @include for-size(desktop-up) {
+        // width: 155px;
+        padding: 8px 40px 8px 25px;
+      }
+
+      @include for-size(big-desktop-up) {
+        // width: 222px;
+        padding: 8px 25px 8px 25px;
+      }
+
+      &:focus {
+        @include for-size(desktop-up) {
+          // width: 222px;
+          padding: 8px 25px 8px 25px;
+        }
+      }
+    }
+
+    .button {
+      color: $sidechain;
+      border-radius: 100px;
+      padding: 8px 16px;
+      margin: 16px 16px;
+      font-size: 14px;
+      border: 1px solid $sidechain;
+      box-sizing: border-box;
     }
 
     @include for-size(tablet-landscape-up) {
@@ -49,143 +120,6 @@
     @include for-size(big-desktop-up) {
       width: 864px;
       padding: 0px 48px 0px 0px;
-    }
-
-    .tab {
-      padding-top: 24px;
-      padding-bottom: 24px;
-      margin-bottom: -1px;
-    }
-  }
-
-  .summary {
-    width: calc(100% - 32px);
-    padding: 30px 0px 20px;
-    margin: 0px auto;
-
-    @include for-size(tablet-landscape-up) {
-      width: 584px;
-    }
-    @include for-size(desktop-up) {
-      width: 820px;
-    }
-    @include for-size(big-desktop-up) {
-      width: 912px;
-    }
-
-    .type {
-      display: inline-block;
-      padding-bottom: 24px;
-      color: $white;
-      font-size: 42px;
-      @include bold;
-    }
-
-    .label {
-      margin-top: 16px;
-      margin-bottom: 4px;
-      color: $black-80;
-      font-size: 24px;
-      line-height: 32px;
-      @include bold;
-
-      @include for-size(tablet-landscape-up) {
-        font-size: 32px;
-        line-height: 40px;
-      }
-      @include for-size(desktop-up) {
-        font-size: 40px;
-        line-height: 48px;
-      }
-      @include for-size(big-desktop-up) {
-        font-size: 40px;
-        line-height: 48px;
-      }
-    }
-
-    .hash {
-      overflow: hidden;
-      padding-bottom: 87px;
-      color: $gray-400;
-      font-size: 12px;
-      letter-spacing: 0px;
-      line-height: 20px;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      @include medium;
-    }
-
-    .status {
-      display: inline-block;
-      padding: 0px 15px 20px;
-      font-size: 10px;
-      line-height: 18px;
-      text-transform: uppercase;
-      vertical-align: middle;
-      @include bold;
-
-      @include for-size(tablet-landscape-up) {
-        font-size: 12px;
-        line-height: 20px;
-      }
-      @include for-size(desktop-up) {
-        font-size: 12px;
-        line-height: 20px;
-      }
-      @include for-size(big-desktop-up) {
-        font-size: 12px;
-        line-height: 20px;
-      }
-
-      &.success {
-        color: $green;
-      }
-
-      &.fail {
-        color: $orange-600;
-
-        span {
-          text-transform: none;
-        }
-      }
-
-      img {
-        position: relative;
-        top: 4px;
-        width: 16px;
-        height: 16px;
-        margin-right: 4px;
-      }
-    }
-  }
-
-  .tab-body {
-    margin: 0px auto;
-
-    @include for-size(tablet-landscape-up) {
-      width: 584px;
-    }
-    @include for-size(desktop-up) {
-      width: 820px;
-    }
-    @include for-size(big-desktop-up) {
-      width: 912px;
-    }
-
-    .react-json-view {
-      overflow: hidden;
-      margin-bottom: 40px;
-      font-size: 12px;
-      letter-spacing: 0px;
-
-      .variable-row,
-      .object-key-val {
-        padding: 1px 5px 1px 15px !important;
-      }
-
-      .copy-icon svg {
-        height: 14px !important;
-      }
     }
   }
 }

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -32,7 +32,7 @@
       align-items: center;
       justify-content: center;
       padding: auto;
-      margin: 100px auto 0px;
+      margin: 100px auto 100px auto;
 
       .sidechain-logo {
         width: 400px;
@@ -128,6 +128,38 @@
       @include for-size(big-desktop-up) {
         width: 864px;
         padding: 0px 48px 0px 0px;
+      }
+    }
+    .custom-network-list {
+      display: flex;
+      flex-direction: column;
+      align-items: normal;
+      margin: 0% 10%;
+      margin-bottom: 70px;
+      color: $white;
+      font-size: 20px;
+      justify-items: right;
+      text-align: left;
+
+      .custom-network-header {
+        border-bottom: 1px solid $black-80;
+        @include bold;
+
+        @include for-size(tablet-landscape-up) {
+          font-size: 24px;
+        }
+      }
+
+      .custom-network-item {
+        border-bottom: 1px solid $black-80;
+        margin: 26px 16px;
+        font-size: 20px;
+
+        &:hover,
+        &:focus {
+          color: $sidechain;
+          cursor: pointer;
+        }
       }
     }
   }

--- a/src/containers/SidechainHome/sidechainhome.scss
+++ b/src/containers/SidechainHome/sidechainhome.scss
@@ -112,7 +112,6 @@
       .custom-network-header {
         padding-bottom: 24px;
         border-bottom: 1px solid $black-80;
-        margin-bottom: 24px;
         font-size: 20px;
         @include bold;
 

--- a/src/containers/SidechainHome/test/SidechainHome.test.js
+++ b/src/containers/SidechainHome/test/SidechainHome.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { I18nextProvider } from 'react-i18next';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { initialState } from '../../../rootReducer';
+import i18n from '../../../i18nTestConfig';
+import SidechainHome from '../index';
+
+describe('SidechainHome page', () => {
+  let wrapper;
+
+  const middlewares = [thunk];
+  const mockStore = configureMockStore(middlewares);
+
+  const createWrapper = (state = {}) => {
+    const store = mockStore({ ...initialState, ...state });
+    return mount(
+      <I18nextProvider i18n={i18n}>
+        <Provider store={store}>
+          <Router>
+            <SidechainHome />
+          </Router>
+        </Provider>
+      </I18nextProvider>
+    );
+  };
+
+  beforeEach(async () => {
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('renders without crashing', () => {
+    const appNode = wrapper.find('.app');
+    expect(appNode.length).toEqual(1);
+
+    const pageNode = wrapper.find('.sidechain-main-page');
+    expect(pageNode.length).toEqual(1);
+  });
+
+  describe('test redirects', () => {
+    const { location } = window;
+    const mockedFunction = jest.fn();
+    const oldEnvs = process.env;
+
+    beforeEach(() => {
+      delete window.location;
+      // mockedFunction = jest.fn();
+      window.location = { assign: mockedFunction };
+      process.env = { ...oldEnvs, REACT_APP_ENVIRONMENT: 'mainnet' };
+
+      wrapper = createWrapper();
+    });
+
+    afterEach(() => {
+      window.location = location;
+      process.env = oldEnvs;
+    });
+
+    it('redirect works when sidechain is entered', () => {
+      // expand dropdown
+      expect(wrapper.find('.sidechain-input').length).toEqual(1);
+      const sidechainInput = wrapper.find('.sidechain-input');
+      sidechainInput.prop('onKeyDown')({ key: 'Enter', currentTarget: { value: 'sidechain_url' } });
+      expect(mockedFunction).toBeCalledWith(
+        `${process.env.REACT_APP_SIDECHAIN_LINK}/sidechain_url`
+      );
+    });
+
+    it('redirect works on button click', () => {
+      const sidechainInput = wrapper.find('.sidechain-input');
+      sidechainInput.simulate('change', { target: { value: 'sidechain_url' } });
+
+      const { ref } = sidechainInput.getElement();
+      ref.current.value = 'sidechain_url';
+
+      const button = wrapper.find('.button');
+      expect(button.length).toEqual(1);
+      button.simulate('click');
+      expect(mockedFunction).toBeCalledWith(
+        `${process.env.REACT_APP_SIDECHAIN_LINK}/sidechain_url`
+      );
+    });
+  });
+});

--- a/src/containers/SidechainHome/test/SidechainHome.test.js
+++ b/src/containers/SidechainHome/test/SidechainHome.test.js
@@ -51,7 +51,6 @@ describe('SidechainHome page', () => {
 
     beforeEach(() => {
       delete window.location;
-      // mockedFunction = jest.fn();
       window.location = { assign: mockedFunction };
       process.env = { ...oldEnvs, REACT_APP_ENVIRONMENT: 'mainnet' };
 
@@ -63,8 +62,7 @@ describe('SidechainHome page', () => {
       process.env = oldEnvs;
     });
 
-    it('redirect works when sidechain is entered', () => {
-      // expand dropdown
+    it('redirect works on `enter` in textbox', () => {
       expect(wrapper.find('.sidechain-input').length).toEqual(1);
       const sidechainInput = wrapper.find('.sidechain-input');
       sidechainInput.prop('onKeyDown')({ key: 'Enter', currentTarget: { value: 'sidechain_url' } });

--- a/src/containers/SidechainHome/test/SidechainHome.test.js
+++ b/src/containers/SidechainHome/test/SidechainHome.test.js
@@ -78,7 +78,7 @@ describe('SidechainHome page', () => {
       const { ref } = sidechainInput.getElement();
       ref.current.value = 'sidechain_url';
 
-      const button = wrapper.find('.button');
+      const button = wrapper.find('.sidechain-input-button');
       expect(button.length).toEqual(1);
       button.simulate('click');
       expect(mockedFunction).toBeCalledWith(

--- a/src/containers/SidechainHome/test/SidechainHome.test.js
+++ b/src/containers/SidechainHome/test/SidechainHome.test.js
@@ -64,8 +64,13 @@ describe('SidechainHome page', () => {
 
     it('redirect works on `enter` in textbox', () => {
       expect(wrapper.find('.sidechain-input').length).toEqual(1);
-      const sidechainInput = wrapper.find('.sidechain-input');
-      sidechainInput.prop('onKeyDown')({ key: 'Enter', currentTarget: { value: 'sidechain_url' } });
+      wrapper.find('.sidechain-input').simulate('change', { target: { value: 'sidechain_url' } });
+
+      wrapper.update();
+      wrapper.find('.sidechain-input').prop('onKeyDown')({
+        key: 'Enter',
+        currentTarget: { value: 'sidechain_url' },
+      });
       expect(mockedFunction).toBeCalledWith(
         `${process.env.REACT_APP_SIDECHAIN_LINK}/sidechain_url`
       );
@@ -74,9 +79,7 @@ describe('SidechainHome page', () => {
     it('redirect works on button click', () => {
       const sidechainInput = wrapper.find('.sidechain-input');
       sidechainInput.simulate('change', { target: { value: 'sidechain_url' } });
-
-      const { ref } = sidechainInput.getElement();
-      ref.current.value = 'sidechain_url';
+      wrapper.update();
 
       const button = wrapper.find('.sidechain-input-button');
       expect(button.length).toEqual(1);

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -280,7 +280,7 @@ class Streams extends Component {
               Log.error(e);
             });
           // update the load fee
-          fetchLoadFee()
+          fetchLoadFee(rippledUrl)
             .then(loadFee => {
               this.onmetric(loadFee);
             })

--- a/src/containers/shared/images/side_arrow_green.svg
+++ b/src/containers/shared/images/side_arrow_green.svg
@@ -1,0 +1,4 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.5 12.6324H19.5" stroke="#19FF83" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 5.63245L19.5 12.6324L12.5 19.6324" stroke="#19FF83" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/containers/shared/images/sidechain_logo.svg
+++ b/src/containers/shared/images/sidechain_logo.svg
@@ -1,0 +1,122 @@
+<svg width="270" height="157" viewBox="0 0 270 157" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_2371_18948" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="60" y="2" width="150" height="150">
+<circle cx="135" cy="76.5054" r="74.5054" fill="#4F5664"/>
+</mask>
+<g mask="url(#mask0_2371_18948)">
+<circle cx="139.457" cy="74.6107" r="100.646" fill="#22252B" fill-opacity="0.5"/>
+</g>
+<path d="M187.082 94.2331L183.976 94.2331L183.976 95.3622L189.572 95.3622C190.112 95.3622 190.55 95.1095 190.55 94.7977L190.55 91.8408L188.594 91.8408L188.594 93.5091L179.136 88.0484C177.99 87.3869 176.133 87.3869 174.987 88.0484L173.291 89.0278L174.673 89.8262L176.37 88.8468C176.752 88.6263 177.371 88.6263 177.753 88.8468L187.082 94.2331Z" fill="#19FF83"/>
+<path d="M185.737 97.8103L183.965 98.8333C182.819 99.4947 180.962 99.4947 179.816 98.8333L170.358 93.3726L170.358 95.0408L168.402 95.0408L168.402 92.084C168.402 91.7722 168.84 91.5194 169.38 91.5194L174.976 91.5194L174.976 92.6485L171.87 92.6485L181.199 98.0349C181.581 98.2553 182.2 98.2553 182.582 98.0349L184.354 97.0119L185.737 97.8103Z" fill="#19FF83"/>
+<path d="M176.594 39.1752L176.594 40.824L178.392 40.824L178.392 37.8539C178.392 37.5673 177.989 37.3349 177.493 37.3349L172.785 37.3349L172.785 38.3729L175.441 38.3729L166.746 43.3929C165.693 44.0009 165.693 44.9867 166.746 45.5948L168.306 46.4951L169.577 45.7612L168.018 44.8608C167.666 44.6581 167.666 44.3295 168.018 44.1268L176.594 39.1752Z" fill="#19FF83"/>
+<path d="M182.29 39.8894L183.919 40.8298C184.972 41.4379 184.972 42.4237 183.919 43.0317L175.224 48.0517L177.88 48.0517L177.88 49.0897L173.172 49.0897C172.676 49.0897 172.273 48.8573 172.273 48.5707L172.273 45.6006L174.071 45.6006L174.071 47.2493L182.647 42.2977C182.998 42.0951 182.998 41.7665 182.647 41.5638L181.018 40.6234L182.29 39.8894Z" fill="#19FF83"/>
+<g filter="url(#filter0_d_2371_18948)">
+<rect x="-2.98023e-08" y="0.5" width="54.9957" height="54.9957" rx="7.5" transform="matrix(0.866025 0.5 -0.866025 0.5 211.896 86.3536)" fill="#004D23" stroke="#19FF83"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(-0.866025 0.5 -0.866025 -0.5 227.388 95.2978)" stroke="#00803B"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(0.866025 0.5 -0.866025 0.5 179.147 104.761)" stroke="#00803B"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(-0.866025 0.5 -0.866025 -0.5 243.647 104.685)" stroke="#00803B"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(0.866025 0.5 -0.866025 0.5 195.406 95.3742)" stroke="#00803B"/>
+<rect x="-2.98023e-08" y="0.5" width="54.9957" height="54.9957" rx="7.5" transform="matrix(0.866025 0.5 -0.866025 0.5 211.896 86.3536)" stroke="#19FF83"/>
+<rect width="5.73538" height="5.73538" transform="matrix(0.866025 0.5 -0.866025 0.5 211.729 101.817)" fill="#00B352"/>
+<rect width="5.73538" height="5.73538" transform="matrix(0.866025 0.5 -0.866025 0.5 195.676 111.086)" fill="#00B352"/>
+<rect width="5.73538" height="5.73538" transform="matrix(0.866025 0.5 -0.866025 0.5 227.782 111.086)" fill="#00B352"/>
+<rect width="5.73538" height="5.73538" transform="matrix(0.866025 0.5 -0.866025 0.5 211.729 120.354)" fill="#00B352"/>
+</g>
+<g filter="url(#filter1_d_2371_18948)">
+<rect x="-2.98023e-08" y="0.5" width="37.3432" height="37.3432" rx="7.5" transform="matrix(0.866025 0.5 -0.866025 0.5 199.846 8.89948)" fill="#004D23" stroke="#19FF83"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(-0.866025 0.5 -0.866025 -0.5 210.317 14.9453)" stroke="#00803B"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(0.866025 0.5 -0.866025 0.5 177.284 21.4254)" stroke="#00803B"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(-0.866025 0.5 -0.866025 -0.5 221.451 21.3731)" stroke="#00803B"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(0.866025 0.5 -0.866025 0.5 188.417 14.9975)" stroke="#00803B"/>
+<rect x="-2.98023e-08" y="0.5" width="37.3432" height="37.3432" rx="7.5" transform="matrix(0.866025 0.5 -0.866025 0.5 199.846 8.89948)" stroke="#19FF83"/>
+<rect width="3.92732" height="3.92732" transform="matrix(0.866025 0.5 -0.866025 0.5 199.595 19.4095)" fill="#00B352"/>
+<rect width="3.92732" height="3.92732" transform="matrix(0.866025 0.5 -0.866025 0.5 188.602 25.7559)" fill="#00B352"/>
+<rect width="3.92732" height="3.92732" transform="matrix(0.866025 0.5 -0.866025 0.5 210.587 25.7559)" fill="#00B352"/>
+<rect width="3.92732" height="3.92732" transform="matrix(0.866025 0.5 -0.866025 0.5 199.595 32.1024)" fill="#00B352"/>
+</g>
+<path d="M82.9174 94.2331L86.0238 94.2331L86.0238 95.3622L80.4278 95.3622C79.8878 95.3622 79.45 95.1095 79.45 94.7977L79.45 91.8408L81.4057 91.8408L81.4057 93.5091L90.8639 88.0484C92.0095 87.3869 93.8669 87.3869 95.0126 88.0484L96.709 89.0278L95.3261 89.8262L93.6297 88.8468C93.2478 88.6263 92.6287 88.6263 92.2468 88.8468L82.9174 94.2331Z" fill="#19FF83"/>
+<path d="M84.263 97.8103L86.0348 98.8333C87.1804 99.4947 89.0379 99.4947 90.1835 98.8333L99.6417 93.3726L99.6417 95.0408L101.597 95.0408L101.597 92.084C101.597 91.7722 101.16 91.5194 100.62 91.5194L95.0236 91.5194L95.0236 92.6485L98.13 92.6485L88.8006 98.0349C88.4187 98.2553 87.7996 98.2553 87.4177 98.0349L85.6459 97.0119L84.263 97.8103Z" fill="#19FF83"/>
+<path d="M93.4056 39.1752L93.4056 40.824L91.6077 40.824L91.6077 37.8539C91.6077 37.5673 92.0102 37.3349 92.5067 37.3349L97.2147 37.3349L97.2147 38.3729L94.5584 38.3729L103.253 43.3929C104.306 44.0009 104.306 44.9867 103.253 45.5948L101.694 46.4951L100.422 45.7612L101.982 44.8608C102.333 44.6581 102.333 44.3295 101.982 44.1268L93.4056 39.1752Z" fill="#19FF83"/>
+<path d="M87.7098 39.8894L86.081 40.8298C85.0278 41.4379 85.0278 42.4237 86.081 43.0317L94.7758 48.0517L92.1195 48.0517L92.1195 49.0897L96.8275 49.0897C97.324 49.0897 97.7265 48.8573 97.7265 48.5707L97.7265 45.6006L95.9286 45.6006L95.9286 47.2493L87.3522 42.2977C87.0012 42.0951 87.0012 41.7665 87.3522 41.5638L88.981 40.6234L87.7098 39.8894Z" fill="#19FF83"/>
+<g filter="url(#filter2_d_2371_18948)">
+<rect x="2.98023e-08" y="0.5" width="54.9957" height="54.9957" rx="7.5" transform="matrix(-0.866025 0.5 0.866025 0.5 58.1031 86.3536)" fill="#004D23" stroke="#19FF83"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(0.866025 0.5 0.866025 -0.5 42.6113 95.2978)" stroke="#00803B"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(-0.866025 0.5 0.866025 0.5 90.8525 104.761)" stroke="#00803B"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(0.866025 0.5 0.866025 -0.5 26.3521 104.685)" stroke="#00803B"/>
+<line y1="-0.5" x2="55.9957" y2="-0.5" transform="matrix(-0.866025 0.5 0.866025 0.5 74.5933 95.3742)" stroke="#00803B"/>
+<rect x="2.98023e-08" y="0.5" width="54.9957" height="54.9957" rx="7.5" transform="matrix(-0.866025 0.5 0.866025 0.5 58.1031 86.3536)" stroke="#19FF83"/>
+<rect width="5.73538" height="5.73538" transform="matrix(-0.866025 0.5 0.866025 0.5 58.2705 101.817)" fill="#00B352"/>
+<rect width="5.73538" height="5.73538" transform="matrix(-0.866025 0.5 0.866025 0.5 74.3237 111.086)" fill="#00B352"/>
+<rect width="5.73538" height="5.73538" transform="matrix(-0.866025 0.5 0.866025 0.5 42.2173 111.086)" fill="#00B352"/>
+<rect width="5.73538" height="5.73538" transform="matrix(-0.866025 0.5 0.866025 0.5 58.2705 120.354)" fill="#00B352"/>
+</g>
+<g filter="url(#filter3_d_2371_18948)">
+<rect x="2.98023e-08" y="0.5" width="37.3432" height="37.3432" rx="7.5" transform="matrix(-0.866025 0.5 0.866025 0.5 70.1539 8.89948)" fill="#004D23" stroke="#19FF83"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(0.866025 0.5 0.866025 -0.5 59.6821 14.9453)" stroke="#00803B"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(-0.866025 0.5 0.866025 0.5 92.7158 21.4254)" stroke="#00803B"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(0.866025 0.5 0.866025 -0.5 48.5488 21.3731)" stroke="#00803B"/>
+<line y1="-0.5" x2="38.3432" y2="-0.5" transform="matrix(-0.866025 0.5 0.866025 0.5 81.582 14.9975)" stroke="#00803B"/>
+<rect x="2.98023e-08" y="0.5" width="37.3432" height="37.3432" rx="7.5" transform="matrix(-0.866025 0.5 0.866025 0.5 70.1539 8.89948)" stroke="#19FF83"/>
+<rect width="3.92732" height="3.92732" transform="matrix(-0.866025 0.5 0.866025 0.5 70.4048 19.4095)" fill="#00B352"/>
+<rect width="3.92732" height="3.92732" transform="matrix(-0.866025 0.5 0.866025 0.5 81.3975 25.7559)" fill="#00B352"/>
+<rect width="3.92732" height="3.92732" transform="matrix(-0.866025 0.5 0.866025 0.5 59.4126 25.7559)" fill="#00B352"/>
+<rect width="3.92732" height="3.92732" transform="matrix(-0.866025 0.5 0.866025 0.5 70.4048 32.1024)" fill="#00B352"/>
+</g>
+<g filter="url(#filter4_d_2371_18948)">
+<rect width="78.5416" height="78.5416" rx="8" transform="matrix(0.866025 0.5 -0.866025 0.5 135 30.1941)" fill="#383D47"/>
+<line y1="-0.5" x2="78.5416" y2="-0.5" transform="matrix(-0.866026 0.5 -0.866025 -0.5 157.337 43.0903)" stroke="#4F5664"/>
+<line y1="-0.5" x2="78.5417" y2="-0.5" transform="matrix(0.866025 0.5 -0.866025 0.5 89.6719 56.3642)" stroke="#4F5664"/>
+<line y1="-0.5" x2="78.5416" y2="-0.5" transform="matrix(-0.866026 0.5 -0.866025 -0.5 180.143 56.2571)" stroke="#4F5664"/>
+<line y1="-0.5" x2="78.5417" y2="-0.5" transform="matrix(0.866025 0.5 -0.866025 0.5 112.478 43.1974)" stroke="#4F5664"/>
+<rect width="8.04465" height="8.04465" transform="matrix(0.866025 0.5 -0.866025 0.5 135.373 52.2347)" fill="#7E889A"/>
+<rect width="8.04465" height="8.04465" transform="matrix(0.866025 0.5 -0.866025 0.5 112.856 65.2347)" fill="#7E889A"/>
+<rect width="8.04465" height="8.04465" transform="matrix(0.866025 0.5 -0.866025 0.5 157.89 65.2347)" fill="#7E889A"/>
+<rect width="8.04465" height="8.04465" transform="matrix(0.866025 0.5 -0.866025 0.5 135.373 78.2347)" fill="#7E889A"/>
+</g>
+<defs>
+<filter id="filter0_d_2371_18948" x="153.321" y="78.1659" width="116.286" height="78.7249" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42694"/>
+<feGaussianBlur stdDeviation="6.85388"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2371_18948"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2371_18948" result="shape"/>
+</filter>
+<filter id="filter1_d_2371_18948" x="156.557" y="0.711793" width="85.7114" height="61.0724" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42694"/>
+<feGaussianBlur stdDeviation="6.85388"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2371_18948"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2371_18948" result="shape"/>
+</filter>
+<filter id="filter2_d_2371_18948" x="0.393312" y="78.1659" width="116.286" height="78.7249" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42694"/>
+<feGaussianBlur stdDeviation="6.85388"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2371_18948"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2371_18948" result="shape"/>
+</filter>
+<filter id="filter3_d_2371_18948" x="27.7312" y="0.711793" width="85.7114" height="61.0724" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42694"/>
+<feGaussianBlur stdDeviation="6.85388"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2371_18948"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2371_18948" result="shape"/>
+</filter>
+<filter id="filter4_d_2371_18948" x="57.3318" y="22.2564" width="155.336" height="101.271" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.42694"/>
+<feGaussianBlur stdDeviation="6.85388"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2371_18948"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2371_18948" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/rippled/lib/streams.js
+++ b/src/rippled/lib/streams.js
@@ -44,8 +44,8 @@ const fetchLedger = (ledger, rippledUrl, attempts = 0) => {
     });
 };
 
-const fetchLoadFee = () => {
-  return getServerInfo()
+const fetchLoadFee = rippledUrl => {
+  return getServerInfo(rippledUrl)
     .then(result => result.info)
     .then(info => {
       const ledgerFeeInfo = info.validated_ledger;


### PR DESCRIPTION
## High Level Overview of Change

A sidechain's Explorer "home" is at `sidechain.xrpl.org/[node-url]`. There should be something on the page if you go to just `sidechain.xrpl.org` (if no network is chosen). This PR creates that page.

### Context of Change

Sidechain Explorer MVP (this is the last step)

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### TypeScript/Hooks Update

New files are in TypeScript. Other files weren't modified much, so I didn't bother updating them right now.

- [x] Updated files to React Hooks
- [x] Updated files to TypeScript

## Before / After

Desktop:
![image](https://user-images.githubusercontent.com/8029314/155597423-1d65d87d-052d-4349-861c-9ea5a05195a5.png)

Mobile:
![image](https://user-images.githubusercontent.com/8029314/155598226-08199398-8ce1-4e2d-aef2-948e78aba2bc.png)


## Test Plan

Added tests. They both ensure that the page is rendered properly and test that redirects work as expected.
