### PR TITLE
fix: re-add sidechain dropdown to non-sidechain explorers

### DIFF
--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -204,8 +204,7 @@ class Header extends Component {
                       t(`${network}_data`)
                     );
               })}
-              {/* TODO: remove the boolean check below when deploy is successful */}
-              {currentMode === 'sidechain' && this.renderSidechainInput()}
+              {this.renderSidechainInput()}
             </div>
             <div
               className="arrowContainer"

--- a/src/containers/Header/test/Header.test.js
+++ b/src/containers/Header/test/Header.test.js
@@ -84,17 +84,16 @@ describe('Header component', () => {
       wrapper.unmount();
     });
 
-    // TODO: uncomment when deploy is successful (it does pass)
-    // it('redirect on sidechain input works', () => {
-    //   const wrapper = createWrapper();
+    it('redirect on sidechain input works', () => {
+      const wrapper = createWrapper();
 
-    //   const sidechainInput = wrapper.find('[className="sidechain_input"]');
-    //   sidechainInput.prop('onKeyDown')({ key: 'Enter', currentTarget: { value: 'sidechain_url' } });
-    //   expect(mockedFunction).toBeCalledWith(
-    //     `${process.env.REACT_APP_SIDECHAIN_LINK}/sidechain_url`
-    //   );
+      const sidechainInput = wrapper.find('[className="sidechain_input"]');
+      sidechainInput.prop('onKeyDown')({ key: 'Enter', currentTarget: { value: 'sidechain_url' } });
+      expect(mockedFunction).toBeCalledWith(
+        `${process.env.REACT_APP_SIDECHAIN_LINK}/sidechain_url`
+      );
 
-    //   wrapper.unmount();
-    // });
+      wrapper.unmount();
+    });
   });
 });


### PR DESCRIPTION
## High Level Overview of Change

This PR re-adds the sidechain input to the network dropdown in the mainnet/devnet/testnet/NFT-devnet versions of the explorer.

### Context of Change

Because sidechains were deployed for the first time in #104, it was recommended that we hide the sidechain-related features from the already-existing networks, because there would be some lag between deploying and having the URL all set up for sidechains.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Also uncommented a test. CI passes.