### PR TITLE
fix: failover to `ws` if `wss` fails

### DIFF
--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -231,7 +231,6 @@ class Streams extends Component {
   connect() {
     const rippledUrl = this.context;
     const rippledWsUrl = `wss://${rippledUrl}:${process.env.REACT_APP_RIPPLED_WS_PORT}`;
-    console.log(rippledUrl);
     this.startWs(
       rippledUrl == null ? DEFAULT_WS_URL : rippledWsUrl,
       rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
@@ -246,9 +245,7 @@ class Streams extends Component {
     // handle error
     this.ws.onclose = e => {
       Log.warn(`ws closed`);
-      console.log(e);
       if (!e.wasClean) {
-        console.log(wsUrl.replace('wss://', 'ws://'));
         this.startWs(wsUrl.replace('wss://', 'ws://'), rippledUrl);
       }
     };
@@ -256,8 +253,6 @@ class Streams extends Component {
     // handle error
     this.ws.onerror = e => {
       Log.error(e.toString());
-      console.log(e.data);
-      console.log(e.toString().includes('Websocket connection to'));
     };
 
     // subscribe and save new connections

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -231,11 +231,15 @@ class Streams extends Component {
   connect() {
     const rippledUrl = this.context;
     const rippledWsUrl = `wss://${rippledUrl}:${process.env.REACT_APP_RIPPLED_WS_PORT}`;
-    this.startWs(rippledUrl == null ? DEFAULT_WS_URL : rippledWsUrl);
+    console.log(rippledUrl);
+    this.startWs(
+      rippledUrl == null ? DEFAULT_WS_URL : rippledWsUrl,
+      rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
+    );
   }
 
-  startWs(url) {
-    this.ws = new WebSocket(url);
+  startWs(wsUrl, rippledUrl) {
+    this.ws = new WebSocket(wsUrl);
     this.ws.last = Date.now();
     Log.info(`connecting...`);
 
@@ -244,8 +248,8 @@ class Streams extends Component {
       Log.warn(`ws closed`);
       console.log(e);
       if (!e.wasClean) {
-        console.log(url.replace('wss://', 'ws://'));
-        this.startWs(url.replace('wss://', 'ws://'));
+        console.log(wsUrl.replace('wss://', 'ws://'));
+        this.startWs(wsUrl.replace('wss://', 'ws://'), rippledUrl);
       }
     };
 
@@ -282,7 +286,7 @@ class Streams extends Component {
         } else if (streamResult.type === 'ledgerClosed') {
           const { ledger, metrics } = handleLedger(streamResult);
           this.onledger(ledger);
-          fetchLedger(ledger, url)
+          fetchLedger(ledger, rippledUrl)
             .then(ledgerSummary => {
               this.onledgerSummary(ledgerSummary);
             })
@@ -291,7 +295,7 @@ class Streams extends Component {
               Log.error(e);
             });
           // update the load fee
-          fetchLoadFee(url)
+          fetchLoadFee(rippledUrl)
             .then(loadFee => {
               this.onmetric(loadFee);
             })


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a failover for the streams, so that if `wss` fails, then it attempts to use `ws`.

### Context of Change

Some sidechains may not have certs set up, and may have only `ws` set up. But the Explorer currently expects them to be `wss`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. Tested locally and it works

## Future Tasks
The startup for the stream takes a bit of time. We should see if we can make it faster somehow.