### PR TITLE
fix: add support for non-SSL nodes

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -45,7 +45,8 @@ class App extends Component {
       params: { rippledUrl = null },
     } = match;
     const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST;
-    this.socket = new XrplClient([`wss://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`]);
+    const rippledHostWithPort = `${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`;
+    this.socket = new XrplClient([`wss://${rippledHostWithPort}`, `ws://${rippledHostWithPort}`]);
     this.hasP2PSocket = process.env.REACT_APP_P2P_RIPPLED_HOST !== '';
     this.socket.p2pSocket = this.hasP2PSocket
       ? new XrplClient([


### PR DESCRIPTION
## High Level Overview of Change

This PR adds support for sidechain nodes that don't have SSL set up, and need a `ws` connection instead of a `wss` connection.

### Context of Change

Sidechain nodes might not have SSL set up. Since the Explorer currently expects a `wss` connection, it is unable to connect to those URLs currently.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

No UI changes.

## Test Plan

CI passes.
