### PR TITLE
Revert "fix: add support for non-SSL nodes"

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -45,8 +45,7 @@ class App extends Component {
       params: { rippledUrl = null },
     } = match;
     const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST;
-    const rippledHostWithPort = `${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`;
-    this.socket = new XrplClient([`wss://${rippledHostWithPort}`, `ws://${rippledHostWithPort}`]);
+    this.socket = new XrplClient([`wss://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`]);
     this.hasP2PSocket = process.env.REACT_APP_P2P_RIPPLED_HOST !== '';
     this.socket.p2pSocket = this.hasP2PSocket
       ? new XrplClient([


### PR DESCRIPTION
Reverts ripple/explorer#119

This doesn't work in prod, due to the following error:
```
Uncaught DOMException: Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.
```