### PR TITLE
fix: allow p2p_ripple_host to be null

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -46,7 +46,9 @@ class App extends Component {
     } = match;
     const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST;
     this.socket = new XrplClient([`wss://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`]);
-    this.hasP2PSocket = process.env.REACT_APP_P2P_RIPPLED_HOST !== '';
+    this.hasP2PSocket =
+      process.env.REACT_APP_P2P_RIPPLED_HOST != null &&
+      process.env.REACT_APP_P2P_RIPPLED_HOST !== '';
     this.socket.p2pSocket = this.hasP2PSocket
       ? new XrplClient([
           `wss://${process.env.REACT_APP_P2P_RIPPLED_HOST}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
@@ -69,6 +71,7 @@ class App extends Component {
     const { actions } = this.props;
     window.removeEventListener('resize', actions.updateViewportDimensions);
     window.removeEventListener('scroll', actions.onScroll);
+
     this.socket.close();
     if (this.hasP2PSocket) {
       this.socket.p2pSocket.close();


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

testnet/devnet/nft-devnet had a bunch of `WebSocket connection to 'wss://undefined:51233/' failed` errors.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Worked locally.
