### PR TITLE
fix: websocket closed error thrown upon page load

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -60,11 +60,6 @@ class App extends Component {
     const { actions } = this.props;
     window.addEventListener('resize', actions.updateViewportDimensions);
     window.addEventListener('scroll', actions.onScroll);
-
-    this.socket.reinstate();
-    if (this.hasP2PSocket) {
-      this.socket.p2pSocket.reinstate();
-    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## High Level Overview of Change

The connection is not fully established between App `constructor` and
`componentDidMount`. Calling reinstate was then was closing the connections
before they had a chance and created new ones.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

### Before
![Screen Shot 2022-04-25 at 4 58 23 PM](https://user-images.githubusercontent.com/464895/165182875-d0b895f9-8375-4910-8ab4-478ae821a8b4.png)

### After
No error.
