### PR TITLE
fix: mobile styling of header menu and ledgers page

### DIFF
--- a/src/containers/Header/mobileMenu.scss
+++ b/src/containers/Header/mobileMenu.scss
@@ -6,6 +6,8 @@
   float: right;
   font-family: 'Space Mono', monospace;
   font-size: 14px;
+  // account for regular menu right padding
+  margin-right: -20px;
   text-align: left;
   @include medium;
 

--- a/src/containers/Header/mobileMenu.scss
+++ b/src/containers/Header/mobileMenu.scss
@@ -2,12 +2,12 @@
 
 .mobile-menu {
   padding: 24px 0px;
+  // account for regular menu right padding
+  margin-right: -20px;
   color: $black;
   float: right;
   font-family: 'Space Mono', monospace;
   font-size: 14px;
-  // account for regular menu right padding
-  margin-right: -20px;
   text-align: left;
   @include medium;
 

--- a/src/containers/Ledgers/css/ledgers.scss
+++ b/src/containers/Ledgers/css/ledgers.scss
@@ -71,7 +71,6 @@
   .ledger-list {
     z-index: 20;
     display: flex;
-    width: 100%;
     padding: 0 0 40px 32px;
     margin: -45px 16px 20px 16px;
     background-color: $black;


### PR DESCRIPTION
## High Level Overview of Change

- Fix the ledgers page loading with the menu being off on the right
- Fix being able to offset scroll over to the right the summary and
ledger list

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

### Before
![Screenshot_20220425-194023](https://user-images.githubusercontent.com/464895/165197046-0a3f89aa-7c37-4d4c-b909-c5f14d92d82a.png)
![Screenshot_20220425-194004](https://user-images.githubusercontent.com/464895/165197047-c79ceeab-3fac-4203-ad4b-27b942ea241a.png)

### After 
![Screenshot_20220425-193912](https://user-images.githubusercontent.com/464895/165197187-366a5a99-6495-4d03-b5b4-c11ab1851fcd.png)

