### PR TITLE
refactor: filter networks with new VHS API

### DIFF
--- a/server/routes/v1/validatorReport.js
+++ b/server/routes/v1/validatorReport.js
@@ -3,7 +3,7 @@ const log = require('../../lib/logger')({ name: 'validator-report' });
 
 const fetchValidatorReport = id =>
   axios
-    .get(`${process.env.REACT_APP_DATA_URL}/validators/${id}/reports`)
+    .get(`${process.env.REACT_APP_DATA_URL}/validator/${id}/reports`)
     .then(response => response.data.reports);
 
 module.exports = async (req, res) => {

--- a/server/routes/v1/validators.js
+++ b/server/routes/v1/validators.js
@@ -8,20 +8,6 @@ const fetchValidators = () =>
     .get(`${process.env.REACT_APP_DATA_URL}/validators`)
     .then(response => response.data.validators);
 
-const fetchDomains = () =>
-  axios.get('https://data.ripple.com/v2/network/validators').then(response => {
-    response.data.validators.forEach(d => {
-      if (d.domain) {
-        const validator = cache.validators.find(v => v.master_key === d.validation_public_key);
-        if (validator) {
-          if (!(validator.domain && validator.domain_is_verified)) {
-            validator.domain = d.domain;
-          }
-        }
-      }
-    });
-  });
-
 const cacheValidators = async () => {
   if (!cache.pending) {
     cache.pending = true;
@@ -43,7 +29,6 @@ const cacheValidators = async () => {
       }
       cache.time = Date.now();
       cache.pending = false;
-      await fetchDomains();
     } catch (e) {
       cache.pending = false;
       log.error(e.toString());

--- a/server/routes/v1/validators.js
+++ b/server/routes/v1/validators.js
@@ -1,19 +1,11 @@
 const axios = require('axios');
 const log = require('../../lib/logger')({ name: 'validators' });
 
-const ENV_NETWORK_MAP = {
-  mainnet: 'main',
-  testnet: 'test',
-  devnet: 'dev',
-  'nft-devnet': 'nft-dev',
-};
-
 const cache = {};
 
 const fetchValidators = () => {
-  const network = ENV_NETWORK_MAP[process.env.REACT_APP_ENVIRONMENT];
   return axios
-    .get(`${process.env.REACT_APP_DATA_URL}/validators/${network}`)
+    .get(`${process.env.REACT_APP_DATA_URL}/validators/${process.env.REACT_APP_VALIDATOR}`)
     .then(response => response.data.validators);
 };
 


### PR DESCRIPTION
## High Level Overview of Change

This PR filters nodes based on network using the new VHS API filters.

### Context of Change

https://github.com/ripple/validator-history-service/pull/32

NOTE: This PR should not be merged/deployed until the changes to the VHS have been deployed

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### TypeScript/Hooks Update

N/A

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

No real change, though with the new VHS updates, more validators show up on the proper networks.

## Test Plan

CI passes. Works locally, with the VHS staging API endpoints.
