### PR TITLE
chore(deps): Remove node-fetch as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "jest-enzyme": "^7.1.0",
         "localforage": "^1.7.1",
         "moment": "^2.29.1",
-        "node-fetch": "^2.6.1",
         "node-sass-chokidar": "^1.5.0",
         "payid-lib": "^0.1.0",
         "prop-types": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "jest-enzyme": "^7.1.0",
     "localforage": "^1.7.1",
     "moment": "^2.29.1",
-    "node-fetch": "^2.6.1",
     "node-sass-chokidar": "^1.5.0",
     "payid-lib": "^0.1.0",
     "prop-types": "^15.6.1",

--- a/src/containers/Transactions/Simple/EnableAmendment.jsx
+++ b/src/containers/Transactions/Simple/EnableAmendment.jsx
@@ -1,5 +1,5 @@
+import axios from 'axios';
 import React, { Component } from 'react';
-import fetch from 'node-fetch';
 import PropTypes from 'prop-types';
 import { createHash } from 'crypto';
 import { localizeDate } from '../../shared/utils';
@@ -26,10 +26,10 @@ const DATE_OPTIONS = {
 
 class EnableAmendment extends Component {
   static async fetchAmendmentNames() {
-    const response = await fetch(
+    const response = await axios.get(
       'https://raw.githubusercontent.com/ripple/rippled/develop/src/ripple/protocol/impl/Feature.cpp'
     );
-    const text = await response.text();
+    const text = response.data;
 
     const amendmentNames = [];
     text.split('\n').forEach(line => {


### PR DESCRIPTION
## High Level Overview of Change
Remove `node-fetch` because it was only used in one place versus `axios` which was used in 8 places.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript
