### PR TITLE
fix(styling): dex pairs fit page and use currency code instead of hex

### DIFF
--- a/src/containers/Token/DEXPairs/PairStats.js
+++ b/src/containers/Token/DEXPairs/PairStats.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ReactComponent as PairLine } from '../../shared/images/pair_line.svg';
+import Currency from '../../shared/components/Currency';
 
 const PairStats = props => {
   const { pair } = props;
@@ -20,15 +21,15 @@ const PairStats = props => {
               <span className="low-num">
                 {low.num}
                 {low.unit}
-              </span>
-              {` ${token}`}
+              </span>{' '}
+              <Currency currency={token} />
             </td>
             <td className="high">
               <span className="high-num">
                 {high.num}
                 {high.unit}
-              </span>
-              {` ${token}`}
+              </span>{' '}
+              <Currency currency={token} />
             </td>
           </tr>
           <tr>

--- a/src/containers/Token/DEXPairs/index.js
+++ b/src/containers/Token/DEXPairs/index.js
@@ -14,6 +14,7 @@ import {
 import { getOffers } from '../../../rippled';
 import PairStats from './PairStats';
 import SocketContext from '../../shared/SocketContext';
+import Currency from '../../shared/components/Currency';
 
 // Hard Coded Pairs that we always check for
 const pairsHardCoded = [
@@ -120,7 +121,8 @@ const DEXPairs = props => {
     return (
       <tr key={`${pair.token}.${pair.issuer}`}>
         <td className="pair">
-          {`${currency.toUpperCase()}/${pair.token} ${pair.average.num}${pair.average.unit}`}
+          <Currency currency={currency} />/<Currency currency={pair.token} /> {pair.average.num}{' '}
+          {pair.average.unit}
         </td>
         <td className="issuer-address">
           {pair.issuer !== undefined ? (
@@ -138,7 +140,7 @@ const DEXPairs = props => {
 
   return (
     <div className="section dex-pairs-container">
-      <div className="title"> {t('top_trading_pairs')}</div>
+      a<div className="title"> {t('top_trading_pairs')}</div>
       <div className="pairs-table">
         <table>
           <thead>

--- a/src/containers/Token/DEXPairs/styles.scss
+++ b/src/containers/Token/DEXPairs/styles.scss
@@ -28,12 +28,7 @@
         font-size: 18px;
         text-align: center;
       }
-      .pair-header {
-        padding-right: 8%;
-      }
-      .stats-header {
-        padding-left: 8%;
-      }
+
       td {
         width: 200px;
         padding: 2px 5px;
@@ -63,9 +58,8 @@
       }
 
       .pair-stats-container {
-        float: right;
         table {
-          width: 422px;
+          width: 100%;
         }
         td {
           border: none;
@@ -73,6 +67,7 @@
         .low {
           text-align: left;
         }
+
         .low-num {
           color: #19ff83;
         }

--- a/src/containers/Token/TokenHeader/index.js
+++ b/src/containers/Token/TokenHeader/index.js
@@ -10,6 +10,7 @@ import '../../shared/css/nested-menu.css';
 import './styles.css';
 import { localizeNumber, formatLargeNumber } from '../../shared/utils';
 import SocketContext from '../../shared/SocketContext';
+import Currency from '../../shared/components/Currency';
 
 const CURRENCY_OPTIONS = {
   style: 'currency',
@@ -193,7 +194,7 @@ class TokenHeader extends Component {
     return (
       <div className="box token-header">
         <div className="section box-header">
-          <span>{currency.toUpperCase()}</span>
+          <Currency currency={currency} />
           {gravatar && <img alt={`${currency} logo`} src={gravatar} />}
         </div>
         <div className="box-content">{loading ? <Loader /> : this.renderHeaderContent()}</div>

--- a/src/containers/shared/images/pair_line.svg
+++ b/src/containers/shared/images/pair_line.svg
@@ -1,10 +1,9 @@
-<svg width="422" height="7" viewBox="0 0 422 7" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="422" height="1" transform="matrix(-1 0 0 1 422 3)" fill="url(#paint0_linear)"/>
-<rect width="1.61809" height="7" transform="matrix(-1 0 0 1 221.809 0)" fill="white"/>
-<defs>
-<linearGradient id="paint0_linear" x1="52.5879" y1="0" x2="269.412" y2="0" gradientUnits="userSpaceOnUse">
-<stop stop-color="#FF6719"/>
-<stop offset="1" stop-color="#19FF83"/>
-</linearGradient>
-</defs>
+<svg height="7" width="100%" fill="none" viewBox="0 0 422 7" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+    <rect width="100%" height="1" transform="" fill="url(#paint0_linear)" y="3px"></rect>
+    <rect width="2" height="7" fill="white" x="50%" y="0"></rect>
+    <defs>
+        <linearGradient id="paint0_linear" x1="20%" y1="0" x2="80%" y2="0" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#FF6719"></stop><stop offset="1" stop-color="#19FF83"></stop>
+        </linearGradient>
+    </defs>
 </svg>


### PR DESCRIPTION
## High Level Overview of Change

- Offer range svg will resize to its container
- Trading pairs show currency code instead of full hex value
- Token page header uses currency code instead of full hex value

### Context of Change

The token pair table would often run off the side the page.  This change makes it happen less likely.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before

![Screen Shot 2022-05-26 at 5 29 36 PM](https://user-images.githubusercontent.com/464895/170590314-e180e3f2-cdce-4526-97a9-cd0b47e2c0f7.png)

![Screen Shot 2022-05-26 at 5 23 11 PM](https://user-images.githubusercontent.com/464895/170590350-50b3e4ea-cdf5-4a2c-993c-360ab97aacde.png)
![Screen Shot 2022-05-26 at 5 20 36 PM](https://user-images.githubusercontent.com/464895/170590398-91cbcee0-0a5d-41fd-8db0-f91624d6a0e7.png)


## After

![Screen Shot 2022-05-26 at 5 29 49 PM](https://user-images.githubusercontent.com/464895/170590326-79b1daca-636d-4b0c-85b1-ea814ce29370.png)
![Screen Shot 2022-05-26 at 5 22 47 PM](https://user-images.githubusercontent.com/464895/170590369-c8d24fc2-f15f-48fa-befc-da072434d371.png)
![Screen Shot 2022-05-26 at 5 20 06 PM](https://user-images.githubusercontent.com/464895/170590388-edd90bb8-c233-4b53-bd34-99a715dcb7be.png)

