### PR TITLE
fix(transaction-table): transactions will reset data on navigation

### DIFF
--- a/src/containers/Accounts/AccountTransactionsTable/index.js
+++ b/src/containers/Accounts/AccountTransactionsTable/index.js
@@ -42,8 +42,10 @@ export const AccountTxTable = props => {
   }, [data]);
 
   useEffect(() => {
+    setTransactions([]);
+    setMarker(null);
     actions.loadAccountTransactions(accountId, undefined, rippledSocket);
-  }, [accountId, actions, rippledSocket]);
+  }, [accountId]);
 
   const loadMoreTransactions = () => {
     actions.loadAccountTransactions(accountId, marker, rippledSocket);

--- a/src/containers/Accounts/AccountTransactionsTable/test/AccountTransactionsTable.test.js
+++ b/src/containers/Accounts/AccountTransactionsTable/test/AccountTransactionsTable.test.js
@@ -1,22 +1,30 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { I18nextProvider } from 'react-i18next';
-import configureMockStore from 'redux-mock-store';
+import { applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Link } from 'react-router-dom';
-import { initialState } from '../../../../rootReducer';
+import rootReducer, { initialState } from '../../../../rootReducer';
 import i18n from '../../../../i18nTestConfig';
-import ConnectedTable, { AccountTxTable } from '../index';
+import ConnectedTable from '../index';
 import TEST_TRANSACTIONS_DATA from './mockTransactions.json';
+import * as actionTypes from '../actionTypes';
+import { loadAccountTransactions } from '../actions';
+
+jest.mock('../actions', () => {
+  return {
+    __esModule: true,
+    loadAccountTransactions: jest.fn(),
+  };
+});
 
 const TEST_ACCOUNT_ID = 'rTEST_ACCOUNT';
 
 describe('AccountTransactionsTable container', () => {
-  const middlewares = [thunk];
-  const mockStore = configureMockStore(middlewares);
-  const creatWrapper = (state = {}) => {
-    const store = mockStore({ ...initialState, ...state });
+  const createWrapper = (state = {}, loadAccountTransactionsImpl = () => () => {}) => {
+    loadAccountTransactions.mockImplementation(loadAccountTransactionsImpl);
+    const store = createStore(rootReducer, applyMiddleware(thunk));
     return mount(
       <I18nextProvider i18n={i18n}>
         <Provider store={store}>
@@ -29,12 +37,12 @@ describe('AccountTransactionsTable container', () => {
   };
 
   it('renders without crashing', () => {
-    const wrapper = creatWrapper();
+    const wrapper = createWrapper();
     wrapper.unmount();
   });
 
   it('renders static parts', () => {
-    const wrapper = creatWrapper();
+    const wrapper = createWrapper();
     expect(wrapper.find('.transactions-table').length).toBe(1);
     wrapper.unmount();
   });
@@ -42,7 +50,7 @@ describe('AccountTransactionsTable container', () => {
   it('renders loader when fetching data', () => {
     const state = { ...initialState };
     state.accountTransactions.loading = true;
-    const wrapper = creatWrapper(state);
+    const wrapper = createWrapper(state);
     expect(wrapper.find('.loader').length).toBe(1);
     wrapper.unmount();
   });
@@ -55,34 +63,24 @@ describe('AccountTransactionsTable container', () => {
         data: TEST_TRANSACTIONS_DATA,
       },
     };
-    const wrapper = creatWrapper(state);
+    const wrapper = createWrapper(state);
     expect(wrapper.find('.loader').length).toBe(1);
     wrapper.unmount();
   });
 
-  it('renders dynamic content with transaction data', () => {
-    const actions = {
-      loadAccountTransactions: Function.prototype,
-    };
-
-    const component = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <AccountTxTable
-            t={d => d}
-            language="en-US"
-            loading={false}
-            data={TEST_TRANSACTIONS_DATA}
-            actions={actions}
-            accountId={TEST_ACCOUNT_ID}
-          />
-        </Router>
-      </I18nextProvider>
-    );
+  it('renders dynamic content with transaction data', done => {
+    const component = createWrapper({}, () => dispatch => {
+      dispatch({ type: actionTypes.FINISHED_LOADING_ACCOUNT_TRANSACTIONS });
+      dispatch({
+        type: actionTypes.ACCOUNT_TRANSACTIONS_LOAD_SUCCESS,
+        data: TEST_TRANSACTIONS_DATA,
+      });
+    });
 
     expect(component.find('.load-more-btn').length).toBe(1);
     expect(component.find('.account-transactions').length).toBe(1);
     expect(component.find('.transaction-li.transaction-li-header').length).toBe(1);
     expect(component.find(Link).length).toBe(20);
+    done();
   });
 });

--- a/src/containers/Token/TokenTransactionsTable/index.js
+++ b/src/containers/Token/TokenTransactionsTable/index.js
@@ -44,8 +44,10 @@ export const TokenTxTable = props => {
   }, [data]);
 
   useEffect(() => {
+    setTransactions([]);
+    setMarker(null);
     actions.loadTokenTransactions(accountId, currency, undefined, rippledSocket);
-  }, [accountId, currency, actions, rippledSocket]);
+  }, [accountId, currency]);
 
   const loadMoreTransactions = () => {
     actions.loadTokenTransactions(accountId, currency, marker, rippledSocket);

--- a/src/containers/Token/TokenTransactionsTable/test/TokenTransactionsTable.test.js
+++ b/src/containers/Token/TokenTransactionsTable/test/TokenTransactionsTable.test.js
@@ -5,19 +5,28 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Link } from 'react-router-dom';
-import { initialState } from '../../../../rootReducer';
+import rootReducer, { initialState } from '../../../../rootReducer';
 import i18n from '../../../../i18nTestConfig';
 import ConnectedTable, { TokenTxTable } from '../index';
 import TEST_TRANSACTIONS_DATA from '../../../Accounts/AccountTransactionsTable/test/mockTransactions.json';
+import { applyMiddleware, createStore } from 'redux';
+import * as actionTypes from '../../../Accounts/AccountTransactionsTable/actionTypes';
+import { loadTokenTransactions } from '../actions';
+
+jest.mock('../actions', () => {
+  return {
+    __esModule: true,
+    loadTokenTransactions: jest.fn(),
+  };
+});
 
 const TEST_ACCOUNT_ID = 'rTEST_ACCOUNT';
 const TEST_CURRENCY = 'abc';
 
 describe('TokenTransactionsTable container', () => {
-  const middlewares = [thunk];
-  const mockStore = configureMockStore(middlewares);
-  const creatWrapper = (state = {}) => {
-    const store = mockStore({ ...initialState, ...state });
+  const createWrapper = (state = {}, loadTokenTransactionsImpl = () => () => {}) => {
+    loadTokenTransactions.mockImplementation(loadTokenTransactionsImpl);
+    const store = createStore(rootReducer, applyMiddleware(thunk));
     return mount(
       <I18nextProvider i18n={i18n}>
         <Provider store={store}>
@@ -30,12 +39,12 @@ describe('TokenTransactionsTable container', () => {
   };
 
   it('renders without crashing', () => {
-    const wrapper = creatWrapper();
+    const wrapper = createWrapper();
     wrapper.unmount();
   });
 
   it('renders static parts', () => {
-    const wrapper = creatWrapper();
+    const wrapper = createWrapper();
     expect(wrapper.find('.transactions-table').length).toBe(1);
     wrapper.unmount();
   });
@@ -43,7 +52,7 @@ describe('TokenTransactionsTable container', () => {
   it('renders loader when fetching data', () => {
     const state = { ...initialState };
     state.accountTransactions.loading = true;
-    const wrapper = creatWrapper(state);
+    const wrapper = createWrapper(state);
     expect(wrapper.find('.loader').length).toBe(1);
     wrapper.unmount();
   });
@@ -56,31 +65,19 @@ describe('TokenTransactionsTable container', () => {
         data: TEST_TRANSACTIONS_DATA,
       },
     };
-    const wrapper = creatWrapper(state);
+    const wrapper = createWrapper(state);
     expect(wrapper.find('.loader').length).toBe(1);
     wrapper.unmount();
   });
 
   it('renders dynamic content with transaction data', () => {
-    const actions = {
-      loadTokenTransactions: Function.prototype,
-    };
-
-    const component = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <TokenTxTable
-            t={d => d}
-            language="en-US"
-            loading={false}
-            data={TEST_TRANSACTIONS_DATA}
-            actions={actions}
-            accountId={TEST_ACCOUNT_ID}
-            currency={TEST_CURRENCY}
-          />
-        </Router>
-      </I18nextProvider>
-    );
+    const component = createWrapper({}, () => dispatch => {
+      dispatch({ type: actionTypes.FINISHED_LOADING_ACCOUNT_TRANSACTIONS });
+      dispatch({
+        type: actionTypes.ACCOUNT_TRANSACTIONS_LOAD_SUCCESS,
+        data: TEST_TRANSACTIONS_DATA,
+      });
+    });
 
     expect(component.find('.load-more-btn').length).toBe(1);
     expect(component.find('.account-transactions').length).toBe(1);


### PR DESCRIPTION
## High Level Overview of Change

Going between two account/token pages caused the transaction list to be a combination of the two addresses' transactions.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
