### PR TITLE
ci: cache npm dependencies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,11 +18,12 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - run: npm install
     - run: npm run test:all
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm install
       - run: npm run test:all
         env:
           REACT_APP_VALIDATOR: vl.ripple.com

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install
+    # - run: npm install
     - run: npm run test:all
       env:
         REACT_APP_VALIDATOR: vl.ripple.com

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,9 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
         id: cache-nodemodules
@@ -40,6 +41,7 @@ jobs:
       - name: Install Dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
+
       - run: npm run test:all
         env:
           REACT_APP_VALIDATOR: vl.ripple.com

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,18 +18,33 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    # - run: npm install
-    - run: npm run test:all
-      env:
-        REACT_APP_VALIDATOR: vl.ripple.com
-        REACT_APP_RIPPLED_WS_PORT: 51233
-        REACT_APP_RIPPLED_HOST: fake.rippled.example.com
-        REACT_APP_MAINNET_LINK: mainnet.example.com
-        REACT_APP_TESTNET_LINK: testnet.example.com
-        REACT_APP_SIDECHAIN_LINK: sidechain.example.com
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm ci
+      - run: npm run test:all
+        env:
+          REACT_APP_VALIDATOR: vl.ripple.com
+          REACT_APP_RIPPLED_WS_PORT: 51233
+          REACT_APP_RIPPLED_HOST: fake.rippled.example.com
+          REACT_APP_MAINNET_LINK: mainnet.example.com
+          REACT_APP_TESTNET_LINK: testnet.example.com
+          REACT_APP_SIDECHAIN_LINK: sidechain.example.com


### PR DESCRIPTION
## High Level Overview of Change

This PR caches `node_modules` to make CI run faster. It shaves about 50-60 seconds off of a run.

### Context of Change

everyone likes fast CI

### Type of Change

- [x] CI

### TypeScript/Hooks Update

N/A

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Works in CI
