### PR TITLE
fix(validators): Make validators table use the color of last ledger hash

### DIFF
--- a/src/containers/Network/ValidatorsTable.jsx
+++ b/src/containers/Network/ValidatorsTable.jsx
@@ -105,8 +105,8 @@ class ValidatorsTable extends Component {
         </td>
         <td
           className="last-ledger"
-          title={d.partial ? 'partial validation' : undefined}
           style={{ color }}
+          title={d.partial ? 'partial validation' : undefined}
         >
           <Link to={`/ledgers/${d.ledger_index}`}>{d.ledger_index}</Link>
           {d.partial && '*'}

--- a/src/containers/Network/ValidatorsTable.jsx
+++ b/src/containers/Network/ValidatorsTable.jsx
@@ -105,8 +105,8 @@ class ValidatorsTable extends Component {
         </td>
         <td
           className="last-ledger"
-          style={{ color }}
           title={d.partial ? 'partial validation' : undefined}
+          style={{ color }}
         >
           <Link to={`/ledgers/${d.ledger_index}`}>{d.ledger_index}</Link>
           {d.partial && '*'}

--- a/src/containers/Network/css/validatorsTable.scss
+++ b/src/containers/Network/css/validatorsTable.scss
@@ -48,9 +48,16 @@
     .last-ledger {
       min-width: 55px;
       @include bold;
+
+      // When a validation comes in we update the color to use the ledgers hash. Until that occurs the table's default
+      // text color is used.
+      a {
+        color: inherit;
+      }
     }
 
-    .unl, .n-unl {
+    .unl,
+    .n-unl {
       max-width: 40px;
     }
 


### PR DESCRIPTION
Moved color style from the `<td>` to `<a>`.

Closes #231

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

### Before
![Screen Shot 2022-08-11 at 10 10 54 AM](https://user-images.githubusercontent.com/464895/184169846-d003978b-a527-43a4-9dda-640790bf2efc.png)

### After
![Screen Shot 2022-08-11 at 10 24 17 AM](https://user-images.githubusercontent.com/464895/184170021-327f3c1c-f934-45ef-b8c6-fed0904fd4ef.png)
![Uploading Screen Shot 2022-08-11 at 12.17.56 PM.png…]()

