### PR TITLE
fix: `SignerListSet` instruction types

### DIFF
--- a/src/containers/Accounts/AccountHeader/index.js
+++ b/src/containers/Accounts/AccountHeader/index.js
@@ -137,7 +137,7 @@ const AccountHeader = (props) => {
             <li className="quorum">
               <b>{signerList.quorum}</b>
               <span className="label"> {t('out_of')} </span>
-              <b>{signerList.max}</b>
+              <b>{signerList.maxSigners}</b>
               <span className="label"> {t('required')}</span>
             </li>
           </ul>
@@ -330,7 +330,7 @@ AccountHeader.propTypes = {
         }),
       ),
       quorum: PropTypes.number,
-      max: PropTypes.number,
+      maxSigners: PropTypes.number,
     }),
     info: PropTypes.shape({
       reserve: PropTypes.number,

--- a/src/containers/Token/TokenHeader/index.js
+++ b/src/containers/Token/TokenHeader/index.js
@@ -258,7 +258,7 @@ TokenHeader.propTypes = {
         map: PropTypes.func,
       }),
       quorum: PropTypes.number,
-      max: PropTypes.number,
+      maxSigners: PropTypes.number,
     }),
     flags: PropTypes.arrayOf(PropTypes.string),
     xAddress: PropTypes.shape({

--- a/src/containers/Transactions/Simple/SignerListSet.jsx
+++ b/src/containers/Transactions/Simple/SignerListSet.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Account from '../../shared/components/Account'
 
-const SetRegularKey = (props) => {
+const SignerListSet = (props) => {
   const { data, t } = props
-  const { quorum, max, signers } = data.instructions
+  const { quorum, maxSigners, signers } = data.instructions
 
   return (
     <>
@@ -27,19 +27,19 @@ const SetRegularKey = (props) => {
         <div className="value">
           {quorum}
           <span className="label"> {t('out_of')} </span>
-          {max}
+          {maxSigners}
         </div>
       </div>
     </>
   )
 }
 
-SetRegularKey.propTypes = {
+SignerListSet.propTypes = {
   t: PropTypes.func.isRequired,
   data: PropTypes.shape({
     instructions: PropTypes.shape({
       quorum: PropTypes.number,
-      max: PropTypes.number,
+      maxSigners: PropTypes.number,
       signers: PropTypes.shape({
         map: PropTypes.func,
       }),
@@ -47,4 +47,4 @@ SetRegularKey.propTypes = {
   }).isRequired,
 }
 
-export default SetRegularKey
+export default SignerListSet

--- a/src/containers/Transactions/Simple/SignerListSet.jsx
+++ b/src/containers/Transactions/Simple/SignerListSet.jsx
@@ -40,9 +40,12 @@ SignerListSet.propTypes = {
     instructions: PropTypes.shape({
       quorum: PropTypes.number,
       maxSigners: PropTypes.number,
-      signers: PropTypes.shape({
-        map: PropTypes.func,
-      }),
+      signers: PropTypes.arrayOf(
+        PropTypes.shape({
+          account: PropTypes.string,
+          weight: PropTypes.number,
+        }),
+      ),
     }),
   }).isRequired,
 }

--- a/src/containers/shared/components/Transaction/types.ts
+++ b/src/containers/shared/components/Transaction/types.ts
@@ -14,6 +14,7 @@ export interface Instructions {
     currency: string
     issuer: string
   }
+  maxSigners: number
   signers: any[]
   domain: string
   // eslint-disable-next-line camelcase

--- a/src/containers/shared/components/TxDetails.tsx
+++ b/src/containers/shared/components/TxDetails.tsx
@@ -21,6 +21,7 @@ interface Instructions {
     currency: string
     issuer: string
   }
+  maxSigners: number
   signers: any[]
   domain: string
   // eslint-disable-next-line camelcase
@@ -176,14 +177,14 @@ const TxDetails = (props: Props) => {
 
   function renderSignerListSet(): ReactElement {
     const { instructions } = props
-    const { quorum, max, signers } = instructions
+    const { quorum, maxSigners, signers } = instructions
     return (
       <div>
         <span className="label">{t('signers')}:</span>{' '}
         <span>{signers.length}</span>
         {' - '}
         <span className="label">{t('quorum')}:</span>{' '}
-        <span>{`${quorum}/${max}`}</span>
+        <span>{`${quorum}/${maxSigners}`}</span>
       </div>
     )
   }
@@ -442,6 +443,7 @@ TxDetails.propTypes = {
       currency: PropTypes.string.isRequired,
       issuer: PropTypes.string.isRequired,
     }),
+    maxSigners: PropTypes.number,
     signers: PropTypes.arrayOf(PropTypes.shape({})),
     domain: PropTypes.string,
     email_hash: PropTypes.string,

--- a/src/rippled/lib/utils.js
+++ b/src/rippled/lib/utils.js
@@ -51,7 +51,7 @@ const convertRippleDate = (date) =>
 
 const formatSignerList = (data) => ({
   quorum: data.SignerQuorum,
-  max: data.SignerEntries.reduce(
+  maxSigners: data.SignerEntries.reduce(
     (total, d) => total + d.SignerEntry.SignerWeight,
     0,
   ),


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a couple of errors with SignerListSet types that showed up when testing something else out locally.

### Context of Change

Noticed while working on other stuff

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

This is fixing TS problems mainly.

## Before / After

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/8029314/184648319-93991c33-0a3f-4174-bf22-fdf741f5c3db.png">

No error after.

## Test Plan

The errors no longer show up locally.
