### PR TITLE
fix(amount): Get XRP_BASE from somewhere else and remove eslint disable

### DIFF
--- a/src/containers/shared/components/Amount.tsx
+++ b/src/containers/shared/components/Amount.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { XRP_BASE } from '../../../../server/lib/utils'
-import { CURRENCY_OPTIONS } from '../transactionUtils'
+import { CURRENCY_OPTIONS, XRP_BASE } from '../transactionUtils'
 import { localizeNumber } from '../utils'
 import Currency from './Currency'
 
-interface AmountProps {
+export interface AmountProps {
   value:
     | string
     | {
@@ -13,7 +12,7 @@ interface AmountProps {
         currency: string
         amount: string
       }
-  displayIssuer?: boolean // eslint-disable-line react/require-default-props
+  displayIssuer?: boolean
 }
 
 export const Amount = ({ displayIssuer = true, value }: AmountProps) => {


### PR DESCRIPTION
## High Level Overview of Change

Error is being thrown during compilation

```
You attempted to import ../../../../server/lib/utils which falls outside of the project src/ directory. Relative imports outside of src/ are not supported.
You can either move it inside src/, or add a symlink to it from project's node_modules/.
```

### Context of Change

The app would not compile when importing XRP_BASE from server folder since it is outside of the source root aka `src`. Getting it from transactionUtils.ts fixes it.

react/require-default-props won't fail if you export a component's props

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
