### PR TITLE
fix(validator): Update unl text to white

### DIFF
--- a/src/containers/Validators/simpleTab.scss
+++ b/src/containers/Validators/simpleTab.scss
@@ -59,10 +59,6 @@
         white-space: nowrap;
       }
 
-      .value.unl.yes {
-        color: #292;
-      }
-
       .value {
         flex-grow: 1;
         padding-left: 5px;
@@ -187,10 +183,6 @@
       &:last-of-type {
         margin-bottom: 0px;
       }
-    }
-
-    .val.unl.yes {
-      color: #292;
     }
   }
 }


### PR DESCRIPTION


## High Level Overview of Change

The green of the UNL status text was too close to the link color.

Related to #224

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before

![Screen Shot 2022-08-16 at 1 22 08 PM](https://user-images.githubusercontent.com/464895/184951327-6667a5ae-d8f7-44db-8370-89e6f3fca89e.png)

## After

![Screen Shot 2022-08-16 at 1 21 43 PM](https://user-images.githubusercontent.com/464895/184951361-fbedd7c1-5e37-4571-9a00-b73772537233.png)

