### PR TITLE
feat: add support for `XChainModifyBridge` tx

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -146,6 +146,7 @@
   "transaction_XChainCommit": "XChain Commit",
   "transaction_XChainCreateBridge": "XChain Create Bridge",
   "transaction_XChainCreateClaimID": "XChain Create Claim ID",
+  "transaction_XChainModifyBridge": "XChain Modify Bridge",
   "transaction_EnableAmendment": "Enable Amendment",
   "transaction_SetFee": "Set Fee",
   "transaction_UNLModify": "UNL Modify",

--- a/src/containers/shared/components/Transaction/XChainClaim/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainClaim/parser.ts
@@ -1,3 +1,5 @@
+import formatAmount from '../../../../../rippled/lib/txSummary/formatAmount'
+
 export function parser(tx: any, meta: any) {
   const affectedNodes = meta.AffectedNodes
   const modifiedAccountRoots = affectedNodes.filter(
@@ -18,6 +20,6 @@ export function parser(tx: any, meta: any) {
     bridgeOwner: doorNode.ModifiedNode.FinalFields.Account,
     claimId: tx.XChainClaimID,
     destination: tx.Destination,
-    amount: tx.Amount,
+    amount: formatAmount(tx.Amount),
   }
 }

--- a/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
@@ -18,7 +18,7 @@ function createWrapper(tx: any) {
   )
 }
 
-function expectText(
+function expectSimpleRowText(
   wrapper: ReactWrapper<any, Readonly<{}>>,
   dataTest: string,
   text: string,
@@ -31,23 +31,27 @@ describe('XChainClaimSimple', () => {
     const wrapper = createWrapper(mockXChainClaim)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'amount', '\uE90010.00 XRP')
-    expectText(wrapper, 'destination', 'rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi')
-    expectText(wrapper, 'claim-id', '5')
+    expectSimpleRowText(wrapper, 'amount', '\uE90010.00 XRP')
+    expectSimpleRowText(
+      wrapper,
+      'destination',
+      'rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi',
+    )
+    expectSimpleRowText(wrapper, 'claim-id', '5')
   })
 })

--- a/src/containers/shared/components/Transaction/XChainCommit/test/XChainCommitSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCommit/test/XChainCommitSimple.test.tsx
@@ -19,7 +19,7 @@ function createWrapper(tx: any) {
   )
 }
 
-function expectText(
+function expectSimpleRowText(
   wrapper: ReactWrapper<any, Readonly<{}>>,
   dataTest: string,
   text: string,
@@ -32,23 +32,23 @@ describe('XChainCommitSimple', () => {
     const wrapper = createWrapper(mockXChainCommit)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'send', '\uE90010.00 XRP')
-    expectText(wrapper, 'claim-id', '4')
+    expectSimpleRowText(wrapper, 'send', '\uE90010.00 XRP')
+    expectSimpleRowText(wrapper, 'claim-id', '4')
     expect(wrapper.find(`[data-test="destination"]`)).not.toExist()
   })
 
@@ -56,23 +56,27 @@ describe('XChainCommitSimple', () => {
     const wrapper = createWrapper(mockXChainCommitInsufficientFunds)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'send', '\uE90010,000.00 XRP')
-    expectText(wrapper, 'claim-id', '3')
-    expectText(wrapper, 'destination', 'rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi')
+    expectSimpleRowText(wrapper, 'send', '\uE90010,000.00 XRP')
+    expectSimpleRowText(wrapper, 'claim-id', '3')
+    expectSimpleRowText(
+      wrapper,
+      'destination',
+      'rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi',
+    )
   })
 })

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/parser.ts
@@ -1,3 +1,5 @@
+import formatAmount from '../../../../../rippled/lib/txSummary/formatAmount'
+
 export function parser(tx: any, meta: any) {
   const affectedNodes = meta.AffectedNodes
   const bridgeMeta = affectedNodes.filter(
@@ -9,8 +11,8 @@ export function parser(tx: any, meta: any) {
     lockingIssue: tx.XChainBridge.LockingChainIssue,
     issuingDoor: tx.XChainBridge.IssuingChainDoor,
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
-    signatureReward: tx.SignatureReward,
-    minAccountCreateAmount: tx.MinAccountCreateAmount,
+    signatureReward: formatAmount(tx.SignatureReward),
+    minAccountCreateAmount: formatAmount(tx.MinAccountCreateAmount),
     bridgeOwner: bridgeMeta.CreatedNode.NewFields.Account,
   }
 }

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
@@ -18,7 +18,7 @@ function createWrapper(tx: any) {
   )
 }
 
-function expectText(
+function expectSimpleRowText(
   wrapper: ReactWrapper<any, Readonly<{}>>,
   dataTest: string,
   text: string,
@@ -31,21 +31,21 @@ describe('XChainCreateBridgeSimple', () => {
     const wrapper = createWrapper(mockXChainCreateBridge)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
   })
 })

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/parser.ts
@@ -1,3 +1,5 @@
+import formatAmount from '../../../../../rippled/lib/txSummary/formatAmount'
+
 export function parser(tx: any, meta: any) {
   const affectedNodes = meta.AffectedNodes
   const bridgeMeta = affectedNodes.filter(
@@ -9,7 +11,7 @@ export function parser(tx: any, meta: any) {
     lockingIssue: tx.XChainBridge.LockingChainIssue,
     issuingDoor: tx.XChainBridge.IssuingChainDoor,
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
-    signatureReward: tx.SignatureReward,
+    signatureReward: formatAmount(tx.SignatureReward),
     otherChainAccount: tx.OtherChainAccount,
     bridgeOwner: bridgeMeta.ModifiedNode.FinalFields.Account,
   }

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
@@ -18,7 +18,7 @@ function createWrapper(tx: any) {
   )
 }
 
-function expectText(
+function expectSimpleRowText(
   wrapper: ReactWrapper<any, Readonly<{}>>,
   dataTest: string,
   text: string,
@@ -31,23 +31,23 @@ describe('XChainCreateClaimIDSimple', () => {
     const wrapper = createWrapper(mockXChainCreateClaimID)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
+    expectSimpleRowText(
       wrapper,
       'other-chain-account',
       'raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym',

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/Simple.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/Simple.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Amount } from '../../Amount'
+import { TransactionSimpleComponent, TransactionSimpleProps } from '../types'
+import { SimpleRow } from '../SimpleRow'
+import { XChainBridge } from '../XChainBridge'
+
+export const Simple: TransactionSimpleComponent = (
+  props: TransactionSimpleProps,
+) => {
+  const { t } = useTranslation()
+  const {
+    data: {
+      instructions: {
+        lockingDoor,
+        lockingIssue,
+        issuingDoor,
+        issuingIssue,
+        signatureReward,
+        minAccountCreateAmount,
+        bridgeOwner,
+      },
+    },
+  } = props
+
+  return (
+    <>
+      <XChainBridge
+        lockingDoor={lockingDoor}
+        lockingIssue={lockingIssue}
+        issuingDoor={issuingDoor}
+        issuingIssue={issuingIssue}
+        signatureReward={signatureReward}
+        bridgeOwner={bridgeOwner}
+      />
+      {minAccountCreateAmount && (
+        <SimpleRow label={t('min_account_create_amount')}>
+          <Amount value={minAccountCreateAmount} />
+        </SimpleRow>
+      )}
+    </>
+  )
+}

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/Simple.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/Simple.tsx
@@ -34,7 +34,10 @@ export const Simple: TransactionSimpleComponent = (
         bridgeOwner={bridgeOwner}
       />
       {minAccountCreateAmount && (
-        <SimpleRow label={t('min_account_create_amount')}>
+        <SimpleRow
+          label={t('min_account_create_amount')}
+          data-test="min-account-create-amount"
+        >
           <Amount value={minAccountCreateAmount} />
         </SimpleRow>
       )}

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/index.ts
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/index.ts
@@ -1,0 +1,9 @@
+import { TransactionMapping } from '../types'
+
+import { Simple } from './Simple'
+import { parser } from './parser'
+
+export const XChainModifyBridgeTransaction: TransactionMapping = {
+  Simple,
+  parser,
+}

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
@@ -2,7 +2,7 @@ export function parser(tx: any, meta: any) {
   const affectedNodes = meta.AffectedNodes
   const bridgeMeta = affectedNodes.filter(
     (node: any) =>
-      node.CreatedNode && node.CreatedNode.LedgerEntryType === 'Bridge',
+      node.ModifiedNode && node.ModifiedNode.LedgerEntryType === 'Bridge',
   )[0]
   return {
     lockingDoor: tx.XChainBridge.LockingChainDoor,
@@ -11,6 +11,6 @@ export function parser(tx: any, meta: any) {
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
     signatureReward: tx.SignatureReward,
     minAccountCreateAmount: tx.MinAccountCreateAmount,
-    bridgeOwner: bridgeMeta.CreatedNode.NewFields.Account,
+    bridgeOwner: bridgeMeta.ModifiedNode.FinalFields.Account,
   }
 }

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
@@ -1,0 +1,16 @@
+export function parser(tx: any, meta: any) {
+  const affectedNodes = meta.AffectedNodes
+  const bridgeMeta = affectedNodes.filter(
+    (node: any) =>
+      node.CreatedNode && node.CreatedNode.LedgerEntryType === 'Bridge',
+  )[0]
+  return {
+    lockingDoor: tx.XChainBridge.LockingChainDoor,
+    lockingIssue: tx.XChainBridge.LockingChainIssue,
+    issuingDoor: tx.XChainBridge.IssuingChainDoor,
+    issuingIssue: tx.XChainBridge.IssuingChainIssue,
+    signatureReward: tx.SignatureReward,
+    minAccountCreateAmount: tx.MinAccountCreateAmount,
+    bridgeOwner: bridgeMeta.CreatedNode.NewFields.Account,
+  }
+}

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
@@ -1,3 +1,5 @@
+import formatAmount from '../../../../../rippled/lib/txSummary/formatAmount'
+
 export function parser(tx: any, meta: any) {
   const affectedNodes = meta.AffectedNodes
   const bridgeMeta = affectedNodes.filter(
@@ -9,8 +11,8 @@ export function parser(tx: any, meta: any) {
     lockingIssue: tx.XChainBridge.LockingChainIssue,
     issuingDoor: tx.XChainBridge.IssuingChainDoor,
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
-    signatureReward: tx.SignatureReward,
-    minAccountCreateAmount: tx.MinAccountCreateAmount,
+    signatureReward: formatAmount(tx.SignatureReward),
+    minAccountCreateAmount: formatAmount(tx.MinAccountCreateAmount),
     bridgeOwner: bridgeMeta.ModifiedNode.FinalFields.Account,
   }
 }

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { I18nextProvider } from 'react-i18next'
+import { BrowserRouter } from 'react-router-dom'
+import { mount, ReactWrapper } from 'enzyme'
+import { Simple } from '../Simple'
+import mockXChainModifyBridge from './mock_data/XChainModifyBridge.json'
+import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
+import i18n from '../../../../../../i18nTestConfig'
+
+function createWrapper(tx: any) {
+  const data = summarizeTransaction(tx, true)
+  return mount(
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>
+        <Simple data={data.details} />
+      </BrowserRouter>
+    </I18nextProvider>,
+  )
+}
+
+function expectText(
+  wrapper: ReactWrapper<any, Readonly<{}>>,
+  dataTest: string,
+  text: string,
+) {
+  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
+}
+
+describe('XChainModifyBridgeSimple', () => {
+  it('renders', () => {
+    const wrapper = createWrapper(mockXChainModifyBridge)
+
+    // check XChainBridge parts
+    expectText(
+      wrapper,
+      'locking-chain-door',
+      'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectText(wrapper, 'locking-chain-issue', 'XRP')
+    expectText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
+    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectText(wrapper, 'signature-reward', '\uE9000.01 XRP')
+  })
+})

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { mount, ReactWrapper } from 'enzyme'
 import { Simple } from '../Simple'
 import mockXChainModifyBridge from './mock_data/XChainModifyBridge.json'
+import mockXChainModifyBridgeMinAccountCreateAmount from './mock_data/XChainModifyBridgeMinAccountCreateAmount.json'
 import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 import i18n from '../../../../../../i18nTestConfig'
 
@@ -47,5 +48,27 @@ describe('XChainModifyBridgeSimple', () => {
     expectText(wrapper, 'issuing-chain-issue', 'XRP')
 
     expectText(wrapper, 'signature-reward', '\uE9000.01 XRP')
+  })
+
+  it('renders MinAccountCreateAmount', () => {
+    const wrapper = createWrapper(mockXChainModifyBridgeMinAccountCreateAmount)
+
+    // check XChainBridge parts
+    expectText(
+      wrapper,
+      'locking-chain-door',
+      'rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).toExist()
+    expectText(wrapper, 'locking-chain-issue', 'XRP')
+    expectText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
+    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectText(wrapper, 'min-account-create-amount', '\uE900100.00 XRP')
   })
 })

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
@@ -19,7 +19,7 @@ function createWrapper(tx: any) {
   )
 }
 
-function expectText(
+function expectSimpleRowText(
   wrapper: ReactWrapper<any, Readonly<{}>>,
   dataTest: string,
   text: string,
@@ -32,43 +32,47 @@ describe('XChainModifyBridgeSimple', () => {
     const wrapper = createWrapper(mockXChainModifyBridge)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'signature-reward', '\uE9000.01 XRP')
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.01 XRP')
   })
 
   it('renders MinAccountCreateAmount', () => {
     const wrapper = createWrapper(mockXChainModifyBridgeMinAccountCreateAmount)
 
     // check XChainBridge parts
-    expectText(
+    expectSimpleRowText(
       wrapper,
       'locking-chain-door',
       'rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).toExist()
-    expectText(wrapper, 'locking-chain-issue', 'XRP')
-    expectText(
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
       wrapper,
       'issuing-chain-door',
       'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
     )
     expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
-    expectText(wrapper, 'issuing-chain-issue', 'XRP')
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
 
-    expectText(wrapper, 'min-account-create-amount', '\uE900100.00 XRP')
+    expectSimpleRowText(
+      wrapper,
+      'min-account-create-amount',
+      '\uE900100.00 XRP',
+    )
   })
 })

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/mock_data/XChainModifyBridge.json
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/mock_data/XChainModifyBridge.json
@@ -1,0 +1,75 @@
+{
+  "tx": {
+    "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    "Fee": "10",
+    "Flags": 0,
+    "LastLedgerSequence": 23,
+    "Sequence": 2,
+    "SignatureReward": "10000",
+    "SigningPubKey": "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+    "TransactionType": "XChainModifyBridge",
+    "TxnSignature": "3045022100A63798DB1B2CD62D01E04C503623E5DFC601C1FEB94D57F080B94358F2F8FAEE022050E04955B6774B107374C556A60B6661D47C926F24B7B92D84D93546659DE29B",
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": "XRP",
+      "LockingChainDoor": "rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR",
+      "LockingChainIssue": "XRP"
+    },
+    "date": "2022-08-18T09:11:30Z"
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+            "Balance": "99999999999999980",
+            "Flags": 0,
+            "OwnerCount": 1,
+            "Sequence": 3
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "2B6AC232AA4C4BE41BF49D2459FA4A0347E1B543A4C92FCEE0821C0201E2E9A8",
+          "PreviousFields": {
+            "Balance": "99999999999999990",
+            "Sequence": 2
+          },
+          "PreviousTxnID": "31BD5F2C0982752A20BB6A4205F7B6ED6576D08AB7927978BF282E8ABEF44467",
+          "PreviousTxnLgrSeq": 3
+        }
+      },
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+            "Balance": "0",
+            "Flags": 0,
+            "OwnerNode": "0",
+            "SignatureReward": "10000",
+            "XChainAccountClaimCount": "0",
+            "XChainAccountCreateCount": "0",
+            "XChainBridge": {
+              "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+              "IssuingChainIssue": "XRP",
+              "LockingChainDoor": "rGQLcxzT3Po9PsCk5Lj9uK7S1juThii9cR",
+              "LockingChainIssue": "XRP"
+            },
+            "XChainClaimID": "0"
+          },
+          "LedgerEntryType": "Bridge",
+          "LedgerIndex": "EFFC3B47E68E9F74206D9C2F0E14279379E483A40A435AF7C7F729FCAD663DB1",
+          "PreviousFields": {
+            "SignatureReward": "100"
+          },
+          "PreviousTxnID": "31BD5F2C0982752A20BB6A4205F7B6ED6576D08AB7927978BF282E8ABEF44467",
+          "PreviousTxnLgrSeq": 3
+        }
+      }
+    ],
+    "TransactionIndex": 0,
+    "TransactionResult": "tesSUCCESS"
+  },
+  "hash": "ADBA23ED812B231559A1DFC76C9BCE566BB7BAEF7A737C3515911AE23050CDDA",
+  "ledger_index": 4,
+  "date": "2022-08-18T09:11:30Z"
+}

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/mock_data/XChainModifyBridgeMinAccountCreateAmount.json
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/mock_data/XChainModifyBridgeMinAccountCreateAmount.json
@@ -1,0 +1,76 @@
+{
+  "tx": {
+    "Account": "rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp",
+    "Fee": "10",
+    "Flags": 0,
+    "LastLedgerSequence": 38,
+    "MinAccountCreateAmount": "100000000",
+    "Sequence": 5,
+    "SigningPubKey": "032389AD44BF4CCE332D3A2333AFBA03CD2EA8EAB31A63F7EF5A608107BDFBFCD7",
+    "TransactionType": "XChainModifyBridge",
+    "TxnSignature": "3044022067C35109504B30AEA17D369DBFB681675E289F1D2CC1DCA1E7F117BB80DD84B002204F206366690DAF7C17CCC8957C3A20816410A5A148FE371C2369E0C0B407AAD1",
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": "XRP",
+      "LockingChainDoor": "rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp",
+      "LockingChainIssue": "XRP"
+    },
+    "date": "2022-09-09T20:19:00Z"
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp",
+            "Balance": "0",
+            "Flags": 0,
+            "MinAccountCreateAmount": "100000000",
+            "OwnerNode": "0",
+            "SignatureReward": "100",
+            "XChainAccountClaimCount": "0",
+            "XChainAccountCreateCount": "1",
+            "XChainBridge": {
+              "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+              "IssuingChainIssue": "XRP",
+              "LockingChainDoor": "rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp",
+              "LockingChainIssue": "XRP"
+            },
+            "XChainClaimID": "0"
+          },
+          "LedgerEntryType": "Bridge",
+          "LedgerIndex": "063F76476DC55CD4FC8A2B1FDD4D3AF2CAB72EB5A19C62DCB2F0CC08953B4093",
+          "PreviousFields": {
+            "MinAccountCreateAmount": "5000000"
+          },
+          "PreviousTxnID": "CB4C23D2CD36DFF66F10B38F29B7CDCE5C44622D470CC438EEEE223832B50717",
+          "PreviousTxnLgrSeq": 18
+        }
+      },
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rnBnyot2gCJywLxLzfHQX2dUJqZ6oghUFp",
+            "Balance": "1015000070",
+            "Flags": 0,
+            "OwnerCount": 2,
+            "Sequence": 6
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "8A4453D12949BE96BE6B1B63E77B165F61CDE7AE852237791F6A2D3726936E1E",
+          "PreviousFields": {
+            "Balance": "1015000080",
+            "Sequence": 5
+          },
+          "PreviousTxnID": "CB4C23D2CD36DFF66F10B38F29B7CDCE5C44622D470CC438EEEE223832B50717",
+          "PreviousTxnLgrSeq": 18
+        }
+      }
+    ],
+    "TransactionIndex": 0,
+    "TransactionResult": "tesSUCCESS"
+  },
+  "hash": "625C6B9481E449AEB1ED454E3643FA123B1573658187A067302F903A65911038",
+  "ledger_index": 19,
+  "date": "2022-09-09T20:19:00Z"
+}

--- a/src/containers/shared/components/Transaction/index.ts
+++ b/src/containers/shared/components/Transaction/index.ts
@@ -4,6 +4,7 @@ import { XChainClaimTransaction as XChainClaim } from './XChainClaim'
 import { XChainCommitTransaction as XChainCommit } from './XChainCommit'
 import { XChainCreateBridgeTransaction as XChainCreateBridge } from './XChainCreateBridge'
 import { XChainCreateClaimIDTransaction as XChainCreateClaimID } from './XChainCreateClaimID'
+import { XChainModifyBridgeTransaction as XChainModifyBridge } from './XChainModifyBridge'
 import { TransactionMapping } from './types'
 
 export const transactionTypes: { [key: string]: TransactionMapping } = {
@@ -13,4 +14,5 @@ export const transactionTypes: { [key: string]: TransactionMapping } = {
   XChainCommit,
   XChainCreateBridge,
   XChainCreateClaimID,
+  XChainModifyBridge,
 }

--- a/src/containers/shared/css/global.scss
+++ b/src/containers/shared/css/global.scss
@@ -105,7 +105,8 @@ div.react-stockchart div {
   &.XChainClaim,
   &.XChainCommit,
   &.XChainCreateBridge,
-  &.XChainCreateClaimID {
+  &.XChainCreateClaimID,
+  &.XChainModifyBridge {
     @include transaction-type-base($sidechain);
   }
   /* stylelint-enable selector-class-pattern */

--- a/src/rippled/lib/txSummary/formatAmount.js
+++ b/src/rippled/lib/txSummary/formatAmount.js
@@ -1,5 +1,8 @@
-module.exports = (d) =>
-  d.value
+module.exports = (d) => {
+  if (d == null) {
+    return d
+  }
+  return d.value
     ? {
         currency: d.currency,
         issuer: d.issuer,
@@ -9,3 +12,4 @@ module.exports = (d) =>
         currency: 'XRP',
         amount: d / 1000000,
       }
+}


### PR DESCRIPTION
## High Level Overview of Change

This PR adds support for the `XChainModifyBridge` transaction type.

### Context of Change

cross-chain bridge tx support

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### TypeScript/Hooks Update

New files use TypeScript and Hooks.

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a basic test.
