### PR TITLE
fix(simple-tab): Address "wonky" styling of transaction simple view

### DIFF
--- a/src/containers/Transactions/Simple/NFTokenAcceptOffer.jsx
+++ b/src/containers/Transactions/Simple/NFTokenAcceptOffer.jsx
@@ -14,7 +14,7 @@ const NFTokenAcceptOffer = (props) => {
   return (
     <>
       {acceptedOfferIDs.map((offer) => (
-        <div className="row flex-wrap">
+        <div className="row">
           <div className="label">Offer ID</div>
           <div className="value" data-test="offer-id">
             <div className="dt">{offer}</div>
@@ -23,19 +23,19 @@ const NFTokenAcceptOffer = (props) => {
       ))}
       {tokenID && (
         <>
-          <div className="row flex-wrap">
+          <div className="row">
             <div className="label">Seller</div>
             <div className="value account" data-test="seller">
               <Account account={seller} />
             </div>
           </div>
-          <div className="row flex-wrap">
+          <div className="row">
             <div className="label">Buyer</div>
             <div className="value account" data-test="buyer">
               <Account account={buyer} />
             </div>
           </div>
-          <div className="row flex-wrap">
+          <div className="row">
             <div className="label">Token ID</div>
             <div className="value">
               <div className="dt" data-test="token-id">

--- a/src/containers/Transactions/Simple/NFTokenBurn.jsx
+++ b/src/containers/Transactions/Simple/NFTokenBurn.jsx
@@ -9,7 +9,7 @@ const NFTokenBurn = (props) => {
   } = props
 
   return (
-    <div className="row flex-wrap">
+    <div className="row">
       <div className="label">Token ID</div>
       <div className="value">
         <div className="dt" data-test="token-id">

--- a/src/containers/Transactions/Simple/NFTokenCancelOffer.jsx
+++ b/src/containers/Transactions/Simple/NFTokenCancelOffer.jsx
@@ -21,13 +21,13 @@ const NFTokenCancelOffer = (props) => {
           offerer,
         }) => (
           <>
-            <div className="row flex-wrap">
+            <div className="row">
               <div className="label">Offer ID</div>
               <div className="value" data-test="offer-id">
                 <div className="dt">{offerID}</div>
               </div>
             </div>
-            <div className="row flex-wrap">
+            <div className="row">
               <div className="label">Token ID</div>
               <div className="value">
                 <div className="dt" data-test="token-id">

--- a/src/containers/Transactions/Simple/NFTokenCreateOffer.jsx
+++ b/src/containers/Transactions/Simple/NFTokenCreateOffer.jsx
@@ -13,27 +13,27 @@ const NFTokenCreateOffer = (props) => {
 
   return (
     <>
-      <div className="row flex-wrap">
+      <div className="row">
         <div className="label">Offer ID</div>
         <div className="value" data-test="offer-id">
           <div className="dt">{offerID}</div>
         </div>
       </div>
-      <div className="row flex-wrap" data-test="buyer-or-seller">
+      <div className="row" data-test="buyer-or-seller">
         <div className="label">{isSellOffer ? 'Seller' : 'Buyer'}</div>
         <div className="value account">
           <Account account={account} />
         </div>
       </div>
       {!isSellOffer && (
-        <div className="row flex-wrap">
+        <div className="row">
           <div className="label">Owner</div>
           <div className="value account" data-test="owner">
             <Account account={owner} />
           </div>
         </div>
       )}
-      <div className="row flex-wrap">
+      <div className="row">
         <div className="label">Token ID</div>
         <div className="value" data-test="token-id">
           <div className="dt">{tokenID}</div>

--- a/src/containers/Transactions/Simple/NFTokenMint.jsx
+++ b/src/containers/Transactions/Simple/NFTokenMint.jsx
@@ -10,7 +10,7 @@ const NFTokenMint = (props) => {
 
   return (
     <>
-      <div className="row flex-wrap">
+      <div className="row">
         <div className="label">Token ID</div>
         <div className="value">
           <div className="dt" data-test="token-id">

--- a/src/containers/Transactions/SimpleTab.jsx
+++ b/src/containers/Transactions/SimpleTab.jsx
@@ -136,7 +136,7 @@ class SimpleTab extends Component {
     }
 
     return (
-      <div className="simple-body">
+      <div className="simple-body simple-body-tx">
         <div className="rows">
           <Simple
             t={t}

--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -1,11 +1,14 @@
 @import '../shared/css/variables';
 
-.simple-body {
+$subdued-color: $gray-400;
+
+.simple-body-tx {
   .rows {
     .partial-row {
       display: flex;
       overflow: hidden;
       flex-grow: 1;
+      flex-wrap: wrap;
       padding-top: 20px;
       padding-left: 5px;
       color: #944;
@@ -22,7 +25,7 @@
         .currency {
           display: block;
           margin: -1px 0px -16px;
-          color: $gray-400;
+          color: $subdued-color;
           font-size: 11px;
           @include medium;
 
@@ -34,12 +37,11 @@
         }
 
         .dt {
-          display: inline-block;
-          color: $gray-400;
+          color: $subdued-color;
           font-size: 12px;
         }
 
-        .signers {
+        ul {
           margin: 0px;
           list-style: none;
         }
@@ -65,7 +67,7 @@
         &.tx,
         &.channel {
           width: calc(100% - 120px);
-          color: $gray-400;
+          color: $subdued-color;
           font-size: 14px;
           white-space: normal;
           word-break: break-all;

--- a/src/containers/Validators/SimpleTab.jsx
+++ b/src/containers/Validators/SimpleTab.jsx
@@ -116,7 +116,7 @@ class SimpleTab extends Component {
     }
 
     return (
-      <div className="simple-body">
+      <div className="simple-body simple-body-validator">
         <div className="rows">
           <Simple t={t} language={language} data={data} />
           {rowIndex}

--- a/src/containers/Validators/simpleTab.scss
+++ b/src/containers/Validators/simpleTab.scss
@@ -1,17 +1,8 @@
 @import '../shared/css/variables';
 
-.simple-body {
+.simple-body-validator {
   .rows {
     .row {
-      &.flex-wrap {
-        flex-wrap: wrap;
-      }
-
-      .label {
-        display: flex;
-        align-items: center;
-      }
-
       .value {
         img {
           height: 16px;

--- a/src/containers/shared/css/simpleTab.scss
+++ b/src/containers/shared/css/simpleTab.scss
@@ -19,6 +19,7 @@ $index-width: 308px;
 
     .row {
       display: flex;
+      flex-wrap: wrap;
       overflow: hidden;
       padding: 20px 10px;
       border-bottom: 1px solid $gray-800;
@@ -34,7 +35,6 @@ $index-width: 308px;
       }
 
       .label {
-        flex-grow: 1;
         color: $white;
         font-size: 12px;
         line-height: 20px;

--- a/src/containers/shared/css/simpleTab.scss
+++ b/src/containers/shared/css/simpleTab.scss
@@ -19,8 +19,8 @@ $index-width: 308px;
 
     .row {
       display: flex;
-      flex-wrap: wrap;
       overflow: hidden;
+      flex-wrap: wrap;
       padding: 20px 10px;
       border-bottom: 1px solid $gray-800;
 


### PR DESCRIPTION
## High Level Overview of Change

- Make simple tab rows use `flex-wrap: wrap` to more clearly show long values
- Fix nested `.label` causing values to appear wonky like SignerListSet
- Focus validator styles to only apply to validator page and do the same for transactions

Fixes #263

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before

![Screen Shot 2022-08-23 at 3 13 45 PM](https://user-images.githubusercontent.com/464895/186256863-cef944ca-7dbb-41b5-b3d1-111ee82ffa9a.png)

## After

![Screen Shot 2022-08-23 at 3 16 00 PM](https://user-images.githubusercontent.com/464895/186257229-63f9c39f-a27f-41c3-a98d-5663aad71919.png)


## Test Plan

Check transaction and validator pages