### PR TITLE
show zero txn count and fee when ledger has none

### DIFF
--- a/src/containers/Ledgers/Ledgers.jsx
+++ b/src/containers/Ledgers/Ledgers.jsx
@@ -116,7 +116,7 @@ class Ledgers extends Component {
 
   renderTxnCount = (count) => {
     const { t } = this.props
-    return count ? (
+    return count != undefined ? (
       <div className="txn-count">
         {t('txn_count')}:<b>{count.toLocaleString()}</b>
       </div>
@@ -127,7 +127,7 @@ class Ledgers extends Component {
     const { t, language } = this.props
     const options = { ...CURRENCY_OPTIONS, currency: 'XRP' }
     const amount = localizeNumber(d, language, options)
-    return d ? (
+    return d != undefined ? (
       <div className="fees">
         {t('fees')}:<b>{amount}</b>
       </div>


### PR DESCRIPTION
## High Level Overview of Change

When there are no transactions in a ledger, it used to leave the ledger info with blank txn_count and total_fees. Now, it shows it as 0 explicitly.

### Context of Change

Previously, it looked buggy when zero transactions (common on testnet)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before:
![Screen Shot 2022-09-06 at 3 15 13 PM](https://user-images.githubusercontent.com/67431889/188720326-120f0e9d-20d7-4173-b2bd-327f3798b837.png)

After:
![Screen Shot 2022-09-06 at 2 17 23 PM](https://user-images.githubusercontent.com/67431889/188720338-d58d8525-d195-4163-86a9-9024f3d0efd2.png)


## Test Plan

did "npm run lint" and "npm test"

did not write new unit tests
