### PR TITLE
fix(build): Use npm@8 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="Ripple Operations <ops@ripple.com>"
 
 RUN mkdir /explorer
 ADD . / explorer/
+RUN npm i -g npm@8
 RUN npm --prefix explorer install
 RUN chmod +x /explorer/entrypoint.sh
 WORKDIR /explorer


### PR DESCRIPTION
## High Level Overview of Change

Our separate deploy script was failing because it used this Dockerfile which had npm@6 and would fail `engines` check.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release