### PR TITLE
fix(build): Use commit hash for artifacts

### DIFF
--- a/build-non-split.js
+++ b/build-non-split.js
@@ -1,6 +1,10 @@
 const rewire = require('rewire')
 // eslint-disable-next-line import/no-extraneous-dependencies -- webpack comes from create-react-app
 const webpack = require('webpack')
+const commitHash = require('child_process')
+  .execSync('git rev-parse --short HEAD')
+  .toString()
+  .trim()
 
 const defaults = rewire('react-scripts/scripts/build.js')
 // eslint-disable-next-line no-underscore-dangle
@@ -16,9 +20,9 @@ config.optimization.splitChunks = {
 config.optimization.runtimeChunk = false
 
 // JS
-config.output.filename = 'static/js/[name].[hash].js'
+config.output.filename = `static/js/[name].${commitHash}.js`
 // CSS. "5" is MiniCssPlugin
-config.plugins[5].options.filename = 'static/css/[name].[hash].css'
+config.plugins[5].options.filename = `static/css/[name].${commitHash}.css`
 
 // Manually dedupe bn.js@4.2.0 in the bundle
 // TODO: any package that is updated to use bn.js 5.x needs to be removed from `bnJsReplaces`


### PR DESCRIPTION
## High Level Overview of Change

### Context of Change

When the app is built by the deploy process it sometimes produces different hashes.  I cannot figure out why this is.  Using the commit hash is much more deterministic.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release