### PR TITLE
fix(header): Make header sit on top of ledgers

### DIFF
--- a/src/containers/Ledgers/css/ledgers.scss
+++ b/src/containers/Ledgers/css/ledgers.scss
@@ -69,7 +69,6 @@ $ledger-width: 168px;
 
   .ledger-list {
     position: relative;
-    z-index: 20;
     display: flex;
     padding: 0 0 40px 32px;
     margin: -45px 16px 20px;
@@ -77,7 +76,6 @@ $ledger-width: 168px;
   }
 
   .ledger-line {
-    z-index: 0;
     width: 100%;
     height: 45px;
     border-bottom: 1px solid $gray-800;


### PR DESCRIPTION
## High Level Overview of Change

### Context of Change
When the tooltip offset was fixed `position: relative` was added to an element with `z-index` that was doing nothing until that happened.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before
![Screen Shot 2022-09-22 at 11 06 39 AM](https://user-images.githubusercontent.com/464895/191797489-a76d0edd-193f-4ede-b905-c721854b5c46.png)

## After
![Screen Shot 2022-09-22 at 11 06 13 AM](https://user-images.githubusercontent.com/464895/191797526-325357a4-c0de-4815-b5b6-f0d4386fa857.png)

