### PR TITLE
feat: Allow testing with english values

### DIFF
--- a/src/containers/Transactions/test/DetailTab.test.js
+++ b/src/containers/Transactions/test/DetailTab.test.js
@@ -5,33 +5,17 @@ import { I18nextProvider } from 'react-i18next'
 import Transaction from '../../shared/components/Transaction/EscrowCreate/test/mock_data/EscrowCreate.json'
 import FailedTransaction from '../../shared/components/Transaction/SignerListSet/test/mock_data/SignerListSet.json'
 import DetailTab from '../DetailTab'
-import i18n from '../../../i18nTestConfig'
+import i18n from '../../../i18nTestConfig.en-US'
 
 describe('DetailTab container', () => {
-  const createWrapper = (transaction = Transaction) => {
-    i18n.init({
-      lng: 'en-US',
-      resources: {
-        'en-US': {
-          translation: {
-            successful_transaction: 'This transaction was successful',
-            fail_transaction:
-              'This transaction failed with a status code of <0>{{code}}</0>',
-            transaction_validated: ', and validated in ledger ',
-            on: ' on ',
-          },
-        },
-      },
-    })
-
-    return mount(
+  const createWrapper = (transaction = Transaction) =>
+    mount(
       <Router>
         <I18nextProvider i18n={i18n}>
           <DetailTab t={i18n.t} language="en-US" data={transaction} />
         </I18nextProvider>
       </Router>,
     )
-  }
 
   it('renders without crashing', () => {
     const wrapper = createWrapper()
@@ -41,25 +25,25 @@ describe('DetailTab container', () => {
   it('renders all parts', () => {
     const wrapper = createWrapper()
     expect(wrapper.find('.detail-body').length).toBe(1)
-    expect(wrapper.contains(<div className="title">status</div>)).toBe(true)
-    expect(wrapper.contains(<div className="title">description</div>)).toBe(
+    expect(wrapper.contains(<div className="title">Status</div>)).toBe(true)
+    expect(wrapper.contains(<div className="title">Description</div>)).toBe(
       true,
     )
     expect(
       wrapper.contains(
         <div className="title">
-          memos
-          <span>(decoded_hex)</span>
+          Memos
+          <span>(decoded hex)</span>
         </div>,
       ),
     ).toBe(true)
     expect(
       wrapper.contains(
-        <div className="title transaction-cost">transaction_cost</div>,
+        <div className="title transaction-cost">Transaction Cost</div>,
       ),
     ).toBe(true)
-    expect(wrapper.contains(<div className="title">flags</div>)).toBe(true)
-    expect(wrapper.contains(<div className="title">meta</div>)).toBe(true)
+    expect(wrapper.contains(<div className="title">Flags</div>)).toBe(true)
+    expect(wrapper.contains(<div className="title">Meta</div>)).toBe(true)
     wrapper.unmount()
   })
 

--- a/src/i18nTestConfig.en-US.js
+++ b/src/i18nTestConfig.en-US.js
@@ -1,0 +1,15 @@
+import i18n from './i18nTestConfig'
+import translation from '../public/locales/en-US/translations.json'
+
+// Configuration which hardcodes translation to english which helps with complex interpolations
+// This is in a separate file until all tests can be switched over
+i18n.init({
+  lng: 'en-US',
+  resources: {
+    'en-US': {
+      translation,
+    },
+  },
+})
+
+export default i18n


### PR DESCRIPTION
## High Level Overview of Change
Provides an i18n test config to test real interpolation of a strings.  This will improve testing of places that use `<Trans>` and more complex sentences crafted for transaction description sections

### Context of Change

This turns a assertion like:
`payment_desc_line_4 17,366,599.150289 XRdoge.rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA payment_desc_line_5 XRdoge.rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA` 
into 
`It was instructed to deliver 17,366,599.150289 XRdoge.rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA by spending up to XRdoge.rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
