### PR TITLE
feat(tx): Add createWrappers factories and expectation utils

### DIFF
--- a/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelDescription.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import EscrowCancel from './mock_data/EscrowCancel.json'
 import { Description } from '../Description'
 import { createDescriptionWrapperFactory } from '../../test'

--- a/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelDescription.test.tsx
@@ -1,20 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
+
 import EscrowCancel from './mock_data/EscrowCancel.json'
 import { Description } from '../Description'
+import { createDescriptionWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Description data={tx} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createDescriptionWrapperFactory(Description)
 
 describe('EscrowCancelDescription', () => {
   it('renders description for EscrowCancel', () => {

--- a/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelSimple.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockEscrowCancel from './mock_data/EscrowCancel.json'

--- a/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelSimple.test.tsx
@@ -1,22 +1,9 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
-import i18n from '../../../../../../i18nTestConfig'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 import mockEscrowCancel from './mock_data/EscrowCancel.json'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('EscrowCancelSimple', () => {
   it('renders with an expiration and offer', () => {

--- a/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelTableDetail.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { TableDetail } from '../TableDetail'
 import mockEscrowCancel from './mock_data/EscrowCancel.json'
 import { createTableDetailWrapperFactory } from '../../test'

--- a/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCancel/test/EscrowCancelTableDetail.test.tsx
@@ -1,23 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
 import { TableDetail } from '../TableDetail'
-import i18n from '../../../../../../i18nTestConfig'
-import summarize from '../../../../../../rippled/lib/txSummary'
 import mockEscrowCancel from './mock_data/EscrowCancel.json'
+import { createTableDetailWrapperFactory } from '../../test'
 
-const createWrapper = (tx: any) =>
-  mount(
-    <BrowserRouter>
-      <I18nextProvider i18n={i18n}>
-        <TableDetail
-          instructions={summarize(tx, true).details.instructions}
-          type={tx.tx.TransactionType}
-        />
-      </I18nextProvider>
-    </BrowserRouter>,
-  )
+const createWrapper = createTableDetailWrapperFactory(TableDetail)
+
 describe('EscrowCancelTableDetail', () => {
   it('renders EscrowCancel without crashing', () => {
     const wrapper = createWrapper(mockEscrowCancel)

--- a/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateDescription.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import EscrowCreate from './mock_data/EscrowCreate.json'
 import { Description } from '../Description'
 import { createDescriptionWrapperFactory } from '../../test'

--- a/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateDescription.test.tsx
@@ -1,20 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
+
 import EscrowCreate from './mock_data/EscrowCreate.json'
 import { Description } from '../Description'
+import { createDescriptionWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Description data={tx} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createDescriptionWrapperFactory(Description)
 
 describe('EscrowCreateDescription', () => {
   it('renders description for EscrowCreate', () => {

--- a/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateSimple.test.tsx
@@ -1,22 +1,9 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
 import { Simple } from '../Simple'
-import i18n from '../../../../../../i18nTestConfig'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 import mockEscrowCreate from './mock_data/EscrowCreate.json'
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('EscrowCreateSimple', () => {
   it('renders with an expiration and offer', () => {

--- a/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateSimple.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Simple } from '../Simple'
 import mockEscrowCreate from './mock_data/EscrowCreate.json'
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'

--- a/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateTableDetail.test.tsx
@@ -1,23 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
+
+import { createTableDetailWrapperFactory } from '../../test'
 import { TableDetail } from '../TableDetail'
-import i18n from '../../../../../../i18nTestConfig'
-import summarize from '../../../../../../rippled/lib/txSummary'
 import mockEscrowCreate from './mock_data/EscrowCreate.json'
 
-const createWrapper = (tx: any) =>
-  mount(
-    <BrowserRouter>
-      <I18nextProvider i18n={i18n}>
-        <TableDetail
-          instructions={summarize(tx, true).details.instructions}
-          type={tx.tx.TransactionType}
-        />
-      </I18nextProvider>
-    </BrowserRouter>,
-  )
+const createWrapper = createTableDetailWrapperFactory(TableDetail)
+
 describe('EscrowCreateTableDetail', () => {
   it('renders EscrowCreate without crashing', () => {
     const wrapper = createWrapper(mockEscrowCreate)

--- a/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowCreate/test/EscrowCreateTableDetail.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createTableDetailWrapperFactory } from '../../test'
 import { TableDetail } from '../TableDetail'
 import mockEscrowCreate from './mock_data/EscrowCreate.json'

--- a/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishDescription.test.tsx
@@ -1,20 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
+
 import EscrowFinish from './mock_data/EscrowFinish.json'
 import { Description } from '../Description'
+import { createDescriptionWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Description data={tx} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createDescriptionWrapperFactory(Description)
 
 describe('EscrowFinishDescription', () => {
   it('renders description for EscrowFinish', () => {

--- a/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishDescription.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import EscrowFinish from './mock_data/EscrowFinish.json'
 import { Description } from '../Description'
 import { createDescriptionWrapperFactory } from '../../test'

--- a/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishSimple.test.tsx
@@ -1,22 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
+
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
-import i18n from '../../../../../../i18nTestConfig'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 import mockEscrowFinish from './mock_data/EscrowFinish.json'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('EscrowFinishSimple', () => {
   it('renders with an expiration and offer', () => {

--- a/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockEscrowFinish from './mock_data/EscrowFinish.json'

--- a/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishTableDetail.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createTableDetailWrapperFactory } from '../../test'
 import { TableDetail } from '../TableDetail'
 import mockEscrowFinish from './mock_data/EscrowFinish.json'

--- a/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/EscrowFinish/test/EscrowFinishTableDetail.test.tsx
@@ -1,23 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
+
+import { createTableDetailWrapperFactory } from '../../test'
 import { TableDetail } from '../TableDetail'
-import i18n from '../../../../../../i18nTestConfig'
-import summarize from '../../../../../../rippled/lib/txSummary'
 import mockEscrowFinish from './mock_data/EscrowFinish.json'
 
-const createWrapper = (tx: any) =>
-  mount(
-    <BrowserRouter>
-      <I18nextProvider i18n={i18n}>
-        <TableDetail
-          instructions={summarize(tx, true).details.instructions}
-          type={tx.tx.TransactionType}
-        />
-      </I18nextProvider>
-    </BrowserRouter>,
-  )
+const createWrapper = createTableDetailWrapperFactory(TableDetail)
+
 describe('EscrowFinishTableDetail', () => {
   it('renders EscrowFinish without crashing', () => {
     const wrapper = createWrapper(mockEscrowFinish)

--- a/src/containers/shared/components/Transaction/NFTokenAcceptOffer/test/NFTokenAcceptOfferSimple.test.jsx
+++ b/src/containers/shared/components/Transaction/NFTokenAcceptOffer/test/NFTokenAcceptOfferSimple.test.jsx
@@ -1,25 +1,17 @@
 import React from 'react'
-import { BrowserRouter as Router } from 'react-router-dom'
-import { mount } from 'enzyme'
-import { I18nextProvider } from 'react-i18next'
-import { Simple as NFTokenAcceptOffer } from '../Simple'
+
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
+import { Simple } from '../Simple'
 import transactionBuy from './mock_data/NFTokenAcceptOffer_Buy.json'
 import transactionSell from './mock_data/NFTokenAcceptOffer_Sell.json'
 import transactionFailure from './mock_data/NFTokenAcceptOffer_Failure.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
+
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('NFTokenAcceptOffer', () => {
   it('handles NFTokenAcceptOffer Buy simple view ', () => {
-    const wrapper = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <NFTokenAcceptOffer
-            data={summarizeTransaction(transactionBuy, true).details}
-          />
-        </Router>
-      </I18nextProvider>,
-    )
+    const wrapper = createWrapper(transactionBuy)
+
     expect(wrapper.find('[data-test="token-id"] .value')).toHaveText(
       '000800006203F49C21D5D6E022CB16DE3538F248662FC73C29ABA6A90000000D',
     )
@@ -39,15 +31,8 @@ describe('NFTokenAcceptOffer', () => {
   })
 
   it('handles NFTokenAcceptOffer Sell simple view ', () => {
-    const wrapper = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <NFTokenAcceptOffer
-            data={summarizeTransaction(transactionSell, true).details}
-          />
-        </Router>
-      </I18nextProvider>,
-    )
+    const wrapper = createWrapper(transactionSell)
+
     expect(wrapper.find('[data-test="token-id"] .value')).toHaveText(
       '000800006203F49C21D5D6E022CB16DE3538F248662FC73C216B9CBF00000023',
     )
@@ -67,15 +52,8 @@ describe('NFTokenAcceptOffer', () => {
   })
 
   it('handles NFTokenAcceptOffer Sell Failure simple view ', () => {
-    const wrapper = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <NFTokenAcceptOffer
-            data={summarizeTransaction(transactionFailure, true).details}
-          />
-        </Router>
-      </I18nextProvider>,
-    )
+    const wrapper = createWrapper(transactionFailure)
+
     expect(wrapper.find('[data-test="offer-id"] .value')).toHaveText(
       '17AFFE8C8D94554EB3A31A517B05C16085777FAEA9ACEDDCDE9D7CFD7B988D01',
     )

--- a/src/containers/shared/components/Transaction/NFTokenAcceptOffer/test/NFTokenAcceptOfferSimple.test.jsx
+++ b/src/containers/shared/components/Transaction/NFTokenAcceptOffer/test/NFTokenAcceptOfferSimple.test.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import transactionBuy from './mock_data/NFTokenAcceptOffer_Buy.json'

--- a/src/containers/shared/components/Transaction/NFTokenBurn/test/NFTokenBurnSimple.test.jsx
+++ b/src/containers/shared/components/Transaction/NFTokenBurn/test/NFTokenBurnSimple.test.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory } from '../../test'
 import { Simple } from '../Simple'
 import transaction from './mock_data/NFTokenBurn.json'

--- a/src/containers/shared/components/Transaction/NFTokenBurn/test/NFTokenBurnSimple.test.jsx
+++ b/src/containers/shared/components/Transaction/NFTokenBurn/test/NFTokenBurnSimple.test.jsx
@@ -1,21 +1,14 @@
 import React from 'react'
-import { BrowserRouter as Router } from 'react-router-dom'
-import { mount } from 'enzyme'
-import { I18nextProvider } from 'react-i18next'
-import { Simple as NFTokenBurn } from '../Simple'
+
+import { createSimpleWrapperFactory } from '../../test'
+import { Simple } from '../Simple'
 import transaction from './mock_data/NFTokenBurn.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
+
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('NFTokenBurn', () => {
   it('handles NFTokenBurn simple view ', () => {
-    const wrapper = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <NFTokenBurn data={summarizeTransaction(transaction, true).details} />
-        </Router>
-      </I18nextProvider>,
-    )
+    const wrapper = createWrapper(transaction)
     expect(wrapper.find('[data-test="token-id"] .value')).toHaveText(
       '000800006203F49C21D5D6E022CB16DE3538F248662FC73C29ABA6A90000000D',
     )

--- a/src/containers/shared/components/Transaction/NFTokenCreateOffer/test/NFTokenCreateOfferSimple.test.jsx
+++ b/src/containers/shared/components/Transaction/NFTokenCreateOffer/test/NFTokenCreateOfferSimple.test.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory } from '../../test'
 import { Simple } from '../Simple'
 import transactionBuy from './mock_data/NFTokenCreateOffer_Buy.json'

--- a/src/containers/shared/components/Transaction/NFTokenCreateOffer/test/NFTokenCreateOfferSimple.test.jsx
+++ b/src/containers/shared/components/Transaction/NFTokenCreateOffer/test/NFTokenCreateOfferSimple.test.jsx
@@ -1,24 +1,16 @@
 import React from 'react'
-import { BrowserRouter as Router } from 'react-router-dom'
-import { mount } from 'enzyme'
-import { I18nextProvider } from 'react-i18next'
-import { Simple as NFTokenCreateOffer } from '../Simple'
+
+import { createSimpleWrapperFactory } from '../../test'
+import { Simple } from '../Simple'
 import transactionBuy from './mock_data/NFTokenCreateOffer_Buy.json'
 import transactionSell from './mock_data/NFTokenCreateOffer_Sell.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
+
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('NFTokenCreateOffer', () => {
   it('handles NFTokenCreateOffer buy simple view ', () => {
-    const wrapper = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <NFTokenCreateOffer
-            data={summarizeTransaction(transactionBuy, true).details}
-          />
-        </Router>
-      </I18nextProvider>,
-    )
+    const wrapper = createWrapper(transactionBuy)
+
     expect(wrapper.find('[data-test="token-id"] .value')).toHaveText(
       '000800006203F49C21D5D6E022CB16DE3538F248662FC73C2DCBAB9D00000002',
     )
@@ -41,15 +33,8 @@ describe('NFTokenCreateOffer', () => {
   })
 
   it('handles NFTokenCreateOffer sell simple view ', () => {
-    const wrapper = mount(
-      <I18nextProvider i18n={i18n}>
-        <Router>
-          <NFTokenCreateOffer
-            data={summarizeTransaction(transactionSell, true).details}
-          />
-        </Router>
-      </I18nextProvider>,
-    )
+    const wrapper = createWrapper(transactionSell)
+
     expect(wrapper.find('[data-test="token-id"] .value')).toHaveText(
       '000800006203F49C21D5D6E022CB16DE3538F248662FC73C29ABA6A90000000D',
     )

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateDescription.test.tsx
@@ -1,21 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
+
 import OfferCreate from './mock_data/OfferCreateWithExpirationAndCancel.json'
 import OfferCreateInvertedCurrencies from './mock_data/OfferCreateInvertedCurrencies.json'
 import { Description } from '../Description'
+import { createDescriptionWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Description data={tx} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createDescriptionWrapperFactory(Description)
 
 describe('OfferCreate: Description', () => {
   it('renders description for transaction with cancel and expiration', () => {

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateDescription.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import OfferCreate from './mock_data/OfferCreateWithExpirationAndCancel.json'
 import OfferCreateInvertedCurrencies from './mock_data/OfferCreateInvertedCurrencies.json'
 import { Description } from '../Description'

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Simple } from '../Simple'
 import mockOfferCreateWithCancel from './mock_data/OfferCreateWithExpirationAndCancel.json'
 import mockOfferCreate from './mock_data/OfferCreate.json'

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateSimple.test.tsx
@@ -1,23 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
+
 import { Simple } from '../Simple'
 import mockOfferCreateWithCancel from './mock_data/OfferCreateWithExpirationAndCancel.json'
 import mockOfferCreate from './mock_data/OfferCreate.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('OfferCreate: Simple', () => {
   it('renders with an expiration and offer', () => {

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateTableDetail.test.tsx
@@ -1,25 +1,12 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
+
 import { TableDetail } from '../TableDetail'
 import mockOfferCreateInvertedCurrencies from './mock_data/OfferCreateInvertedCurrencies.json'
 import mockOfferCreateWithCancel from './mock_data/OfferCreateWithExpirationAndCancel.json'
 import mockOfferCreate from './mock_data/OfferCreate.json'
+import { createTableDetailWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <TableDetail instructions={data.details.instructions} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createTableDetailWrapperFactory(TableDetail)
 
 describe('OfferCreate: TableDetail', () => {
   it('renders with an expiration and offer', () => {

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateTableDetail.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { TableDetail } from '../TableDetail'
 import mockOfferCreateInvertedCurrencies from './mock_data/OfferCreateInvertedCurrencies.json'
 import mockOfferCreateWithCancel from './mock_data/OfferCreateWithExpirationAndCancel.json'

--- a/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyDescription.test.tsx
@@ -1,21 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
+
 import SetRegularKey from './mock_data/SetRegularKey.json'
 import SetRegularKeyUnset from './mock_data/SetRegularKeyUnsetKey.json'
 import { Description } from '../Description'
+import { createDescriptionWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Description data={tx} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createDescriptionWrapperFactory(Description)
 
 describe('SetRegularKey: Description', () => {
   it('renders description for transaction', () => {

--- a/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyDescription.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import SetRegularKey from './mock_data/SetRegularKey.json'
 import SetRegularKeyUnset from './mock_data/SetRegularKeyUnsetKey.json'
 import { Description } from '../Description'

--- a/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeySimple.test.tsx
+++ b/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeySimple.test.tsx
@@ -1,25 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 import SetRegularKey from './mock_data/SetRegularKey.json'
 import SetRegularKeyUnset from './mock_data/SetRegularKeyUnsetKey.json'
 import { Simple } from '../Simple'
 import { SimpleRow } from '../../SimpleRow'
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('SetRegularKey: Simple', () => {
   it('renders Simple for transaction', () => {

--- a/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeySimple.test.tsx
+++ b/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeySimple.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import SetRegularKey from './mock_data/SetRegularKey.json'
 import SetRegularKeyUnset from './mock_data/SetRegularKeyUnsetKey.json'
 import { Simple } from '../Simple'

--- a/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyTableDetail.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import SetRegularKey from './mock_data/SetRegularKey.json'
 import SetRegularKeyUnset from './mock_data/SetRegularKeyUnsetKey.json'
 import { TableDetail } from '../TableDetail'

--- a/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/SetRegularKey/test/SetRegularKeyTableDetail.test.tsx
@@ -1,24 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
+
 import SetRegularKey from './mock_data/SetRegularKey.json'
 import SetRegularKeyUnset from './mock_data/SetRegularKeyUnsetKey.json'
 import { TableDetail } from '../TableDetail'
+import { createTableDetailWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <TableDetail instructions={data.details.instructions} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createTableDetailWrapperFactory(TableDetail)
 
 describe('SetRegularKeyTable: Detail', () => {
   it('renders Simple for transaction', () => {

--- a/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetDescription.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import mockSignerListSetClear from './mock_data/SignerListSetClear.json'
 import mockSignerListSet from './mock_data/SignerListSet.json'
 import { Description } from '../Description'

--- a/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetDescription.test.tsx
+++ b/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetDescription.test.tsx
@@ -1,21 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
-import i18n from '../../../../../../i18nTestConfig'
+
 import mockSignerListSetClear from './mock_data/SignerListSetClear.json'
 import mockSignerListSet from './mock_data/SignerListSet.json'
 import { Description } from '../Description'
+import { createDescriptionWrapperFactory } from '../../test'
 
-function createWrapper(tx: any) {
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Description data={tx} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createDescriptionWrapperFactory(Description)
 
 describe('SignerListSet: Description', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetSimple.test.tsx
@@ -1,24 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
 import { Simple } from '../Simple'
 import mockSignerListSetClear from './mock_data/SignerListSetClear.json'
 import mockSignerListSet from './mock_data/SignerListSet.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 import { SimpleRow } from '../../SimpleRow'
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('SignerListSet: Simple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetSimple.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Simple } from '../Simple'
 import mockSignerListSetClear from './mock_data/SignerListSetClear.json'
 import mockSignerListSet from './mock_data/SignerListSet.json'

--- a/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetTableDetail.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { TableDetail } from '../TableDetail'
 import mockSignerListSetClear from './mock_data/SignerListSetClear.json'
 import mockSignerListSet from './mock_data/SignerListSet.json'

--- a/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/SignerListSet/test/SignerListSetTableDetail.test.tsx
@@ -1,24 +1,12 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount } from 'enzyme'
+
 import { TableDetail } from '../TableDetail'
 import mockSignerListSetClear from './mock_data/SignerListSetClear.json'
 import mockSignerListSet from './mock_data/SignerListSet.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
-import { SimpleRow } from '../../SimpleRow'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <TableDetail instructions={data.details.instructions} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+import { createTableDetailWrapperFactory } from '../../test'
+
+const createWrapper = createTableDetailWrapperFactory(TableDetail)
 
 describe('SignerListSet: TableDetail', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/XChainAccountCreateCommit/test/XChainAccountCreateCommitSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainAccountCreateCommit/test/XChainAccountCreateCommitSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockXChainAccountCreateCommit from './mock_data/XChainAccountCreateCommit.json'

--- a/src/containers/shared/components/Transaction/XChainAccountCreateCommit/test/XChainAccountCreateCommitSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainAccountCreateCommit/test/XChainAccountCreateCommitSimple.test.tsx
@@ -1,31 +1,12 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
+
+import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockXChainAccountCreateCommit from './mock_data/XChainAccountCreateCommit.json'
 import mockXChainAccountCreateCommitInsufficientFunds from './mock_data/XChainAccountCreateCommitInsufficientFunds.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
+import { expectSimpleRowText } from '../../test/expectations'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
-
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainAccountCreateCommitSimple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/XChainAddAttestation/test/XChainAddAttestationSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainAddAttestation/test/XChainAddAttestationSimple.test.tsx
@@ -1,31 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
+
+import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainAddAttestationAccountCreate from './mock_data/XChainAddAttestationAccountCreate.json'
 import mockXChainAddAttestationClaim from './mock_data/XChainAddAttestationClaim.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
-
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainAddAttestationSimple', () => {
   it('renders AccountCreate element', () => {

--- a/src/containers/shared/components/Transaction/XChainAddAttestation/test/XChainAddAttestationSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainAddAttestation/test/XChainAddAttestationSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainAddAttestationAccountCreate from './mock_data/XChainAddAttestationAccountCreate.json'

--- a/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
@@ -1,30 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
+
+import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainClaim from './mock_data/XChainClaim.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
-
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainClaimSimple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainClaim from './mock_data/XChainClaim.json'

--- a/src/containers/shared/components/Transaction/XChainCommit/test/XChainCommitSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCommit/test/XChainCommitSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Simple } from '../Simple'
 import mockXChainCommit from './mock_data/XChainCommit.json'
 import mockXChainCommitInsufficientFunds from './mock_data/XChainCommitInsufficientFunds.json'

--- a/src/containers/shared/components/Transaction/XChainCommit/test/XChainCommitSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCommit/test/XChainCommitSimple.test.tsx
@@ -1,31 +1,12 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
+
 import { Simple } from '../Simple'
 import mockXChainCommit from './mock_data/XChainCommit.json'
 import mockXChainCommitInsufficientFunds from './mock_data/XChainCommitInsufficientFunds.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
+import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainCommitSimple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
@@ -6,25 +6,9 @@ import { Simple } from '../Simple'
 import mockXChainCreateBridge from './mock_data/XChainCreateBridge.json'
 import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 import i18n from '../../../../../../i18nTestConfig'
+import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
-
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainCreateBridgeSimple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
@@ -1,11 +1,5 @@
-import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
 import { Simple } from '../Simple'
 import mockXChainCreateBridge from './mock_data/XChainCreateBridge.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 
 const createWrapper = createSimpleWrapperFactory(Simple)

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
@@ -1,30 +1,10 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
+
+import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainCreateClaimID from './mock_data/XChainCreateClaimID.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
-
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainCreateClaimIDSimple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainCreateClaimID from './mock_data/XChainCreateClaimID.json'

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainModifyBridge from './mock_data/XChainModifyBridge.json'

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
@@ -1,31 +1,11 @@
 import React from 'react'
-import { I18nextProvider } from 'react-i18next'
-import { BrowserRouter } from 'react-router-dom'
-import { mount, ReactWrapper } from 'enzyme'
+
+import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainModifyBridge from './mock_data/XChainModifyBridge.json'
 import mockXChainModifyBridgeMinAccountCreateAmount from './mock_data/XChainModifyBridgeMinAccountCreateAmount.json'
-import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
-import i18n from '../../../../../../i18nTestConfig'
 
-function createWrapper(tx: any) {
-  const data = summarizeTransaction(tx, true)
-  return mount(
-    <I18nextProvider i18n={i18n}>
-      <BrowserRouter>
-        <Simple data={data.details} />
-      </BrowserRouter>
-    </I18nextProvider>,
-  )
-}
-
-function expectSimpleRowText(
-  wrapper: ReactWrapper<any, Readonly<{}>>,
-  dataTest: string,
-  text: string,
-) {
-  expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)
-}
+const createWrapper = createSimpleWrapperFactory(Simple)
 
 describe('XChainModifyBridgeSimple', () => {
   it('renders', () => {

--- a/src/containers/shared/components/Transaction/test/createWrapperFactory.tsx
+++ b/src/containers/shared/components/Transaction/test/createWrapperFactory.tsx
@@ -1,0 +1,48 @@
+import { mount, ReactWrapper } from 'enzyme'
+import React from 'react'
+import { I18nextProvider } from 'react-i18next'
+import { BrowserRouter } from 'react-router-dom'
+import i18n from '../../../../../i18nTestConfig'
+import summarizeTransaction from '../../../../../rippled/lib/txSummary'
+import {
+  TransactionDescriptionComponent,
+  TransactionSimpleComponent,
+  TransactionTableDetailComponent,
+} from '../types'
+
+export function createWrapper(TestComponent: React.ReactElement): ReactWrapper {
+  return mount(
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>{TestComponent}</BrowserRouter>
+    </I18nextProvider>,
+  )
+}
+
+export function createDescriptionWrapperFactory(
+  Description: TransactionDescriptionComponent,
+): (tx: any) => ReactWrapper {
+  return function createDescriptionWrapper(tx: any) {
+    return createWrapper(<Description data={tx} />)
+  }
+}
+
+export function createSimpleWrapperFactory(
+  Simple: TransactionSimpleComponent,
+): (tx: any) => ReactWrapper {
+  return function createSimpleWrapper(tx: any) {
+    const data = summarizeTransaction(tx, true)
+    return createWrapper(<Simple data={data.details} />)
+  }
+}
+
+export function createTableDetailWrapperFactory(
+  TableDetail: TransactionTableDetailComponent,
+): (tx: any) => ReactWrapper {
+  return function createTableDetailWrapper(tx: any) {
+    const data = summarizeTransaction(tx, true)
+
+    return createWrapper(
+      <TableDetail instructions={data.details.instructions} />,
+    )
+  }
+}

--- a/src/containers/shared/components/Transaction/test/expectations.ts
+++ b/src/containers/shared/components/Transaction/test/expectations.ts
@@ -1,0 +1,13 @@
+import { ReactWrapper } from 'enzyme'
+
+export const expectSimpleRowLabel = (
+  wrapper: ReactWrapper<any, Readonly<{}>>,
+  dataTest: string,
+  text: string,
+) => expect(wrapper.find(`[data-test="${dataTest}"] .label`)).toHaveText(text)
+
+export const expectSimpleRowText = (
+  wrapper: ReactWrapper<any, Readonly<{}>>,
+  dataTest: string,
+  text: string,
+) => expect(wrapper.find(`[data-test="${dataTest}"] .value`)).toHaveText(text)

--- a/src/containers/shared/components/Transaction/test/index.ts
+++ b/src/containers/shared/components/Transaction/test/index.ts
@@ -1,0 +1,2 @@
+export * from './createWrapperFactory'
+export * from './expectations'

--- a/src/rippled/lib/txSummary/index.js
+++ b/src/rippled/lib/txSummary/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { transactionTypes } from '../../../containers/shared/components/Transaction'
 
 const OfferCancel = require('./OfferCancel')


### PR DESCRIPTION
## High Level Overview of Change

- Create a factory to initialize test for each of the transaction type components (Description, Simple, TableDetail).
- Create `expectSimpleRowLabel`
- Move `expectSimpleRowText` to a common spot

### Context of Change

This removes ~380 lines of repeated test harness code.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Future Tasks

Future PRs will make use of `expectSimpleRowLabel` and `expectSimpleRowText`
