### PR TITLE
feat: use `ws` connection when connecting to a local node

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ REACT_APP_ENVIRONMENT=mainnet
 #VHS endpoint url
 REACT_APP_DATA_URL=https://data.xrpl.org/v1/network
 
-# Whether to use ws instead of wss
+# Whether to use ws instead of wss (boolean)
 # Only used locally (the deployed Explorer requires wss)
 REACT_APP_INSECURE_WS=0
 

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ REACT_APP_ENVIRONMENT=mainnet
 #VHS endpoint url
 REACT_APP_DATA_URL=https://data.xrpl.org/v1/network
 
+# Whether to use ws instead of wss
+# Only used locally (the deployed Explorer requires wss)
+REACT_APP_INSECURE_WS=0
+
 #Google Credentials for BigQuery, DO NOT COMMIT THESE
 GOOGLE_APP_PROJECT_ID=
 GOOGLE_APP_PRIVATE_KEY=

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -30,11 +30,11 @@ const App = (props) => {
   const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
   const wsUrls = []
   if (rippledHost.includes(':')) {
-    wsUrls.push(`wss://${rippledHost}`)
+    wsUrls.push(`ws://${rippledHost}`)
   } else {
     wsUrls.push.apply(wsUrls, [
-      `wss://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
-      `wss://${rippledHost}:443`,
+      `ws://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
+      `ws://${rippledHost}:443`,
     ])
   }
   const socket = new XrplClient(wsUrls)
@@ -43,7 +43,7 @@ const App = (props) => {
     process.env.REACT_APP_P2P_RIPPLED_HOST !== ''
   socket.p2pSocket = hasP2PSocket
     ? new XrplClient([
-        `wss://${process.env.REACT_APP_P2P_RIPPLED_HOST}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
+        `ws://${process.env.REACT_APP_P2P_RIPPLED_HOST}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
       ])
     : undefined
 

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -21,6 +21,12 @@ import { NFT } from '../NFT/NFT'
 import SocketContext from '../shared/SocketContext'
 import { queryClient } from '../shared/QueryClient'
 
+const LOCALHOST_URLS = ['localhost', '127.0.0.1', '', '0.0.0.0']
+
+function isLocalRippled(rippledHost) {
+  return LOCALHOST_URLS.some((url) => rippledHost.includes(url))
+}
+
 const App = (props) => {
   const { actions, location, match } = props
 
@@ -28,13 +34,14 @@ const App = (props) => {
     params: { rippledUrl = null },
   } = match
   const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
+  const prefix = isLocalRippled(rippledUrl) ? 'ws' : 'wss'
   const wsUrls = []
   if (rippledHost.includes(':')) {
-    wsUrls.push(`ws://${rippledHost}`)
+    wsUrls.push(`${prefix}://${rippledHost}`)
   } else {
     wsUrls.push.apply(wsUrls, [
-      `ws://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
-      `ws://${rippledHost}:443`,
+      `${prefix}://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
+      `${prefix}://${rippledHost}:443`,
     ])
   }
   const socket = new XrplClient(wsUrls)
@@ -43,7 +50,7 @@ const App = (props) => {
     process.env.REACT_APP_P2P_RIPPLED_HOST !== ''
   socket.p2pSocket = hasP2PSocket
     ? new XrplClient([
-        `ws://${process.env.REACT_APP_P2P_RIPPLED_HOST}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
+        `${prefix}://${process.env.REACT_APP_P2P_RIPPLED_HOST}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
       ])
     : undefined
 

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -37,7 +37,7 @@ const App = (props) => {
     params: { rippledUrl = null },
   } = match
   const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
-  const prefix = isLocalRippled(rippledUrl) ? 'ws' : 'wss'
+  const prefix = isLocalRippled(rippledHost) ? 'ws' : 'wss'
   const wsUrls = []
   if (rippledHost.includes(':')) {
     wsUrls.push(`${prefix}://${rippledHost}`)

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -23,8 +23,9 @@ import { queryClient } from '../shared/QueryClient'
 
 const LOCALHOST_URLS = ['localhost', '127.0.0.1', '0.0.0.0']
 
-function isLocalRippled(rippledHost) {
+function isInsecureWs(rippledHost) {
   return (
+    process.env.REACT_APP_INSECURE_WS ||
     LOCALHOST_URLS.some((url) => rippledHost.includes(url)) ||
     rippledHost === ''
   )
@@ -37,7 +38,7 @@ const App = (props) => {
     params: { rippledUrl = null },
   } = match
   const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
-  const prefix = isLocalRippled(rippledHost) ? 'ws' : 'wss'
+  const prefix = isInsecureWs(rippledHost) ? 'ws' : 'wss'
   const wsUrls = []
   if (rippledHost.includes(':')) {
     wsUrls.push(`${prefix}://${rippledHost}`)

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -21,10 +21,13 @@ import { NFT } from '../NFT/NFT'
 import SocketContext from '../shared/SocketContext'
 import { queryClient } from '../shared/QueryClient'
 
-const LOCALHOST_URLS = ['localhost', '127.0.0.1', '', '0.0.0.0']
+const LOCALHOST_URLS = ['localhost', '127.0.0.1', '0.0.0.0']
 
 function isLocalRippled(rippledHost) {
-  return LOCALHOST_URLS.some((url) => rippledHost.includes(url))
+  return (
+    LOCALHOST_URLS.some((url) => rippledHost.includes(url)) ||
+    rippledHost === ''
+  )
 }
 
 const App = (props) => {

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -31,7 +31,7 @@ function isCustomNetwork(mode) {
 }
 
 function getSocketUrl(socket) {
-  return socket?.endpoint.replace('wss://', '').replace(/:[0-9]+/, '')
+  return socket?.endpoint.replace('wss://', '').replace('ws://', '')
 }
 
 const Header = (props) => {

--- a/src/containers/shared/SocketContext.js
+++ b/src/containers/shared/SocketContext.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const SocketContext = React.createContext(undefined)
-
-export default SocketContext

--- a/src/containers/shared/SocketContext.ts
+++ b/src/containers/shared/SocketContext.ts
@@ -1,0 +1,43 @@
+import React from 'react'
+import { XrplClient } from 'xrpl-client'
+
+const LOCALHOST_URLS = ['localhost', '127.0.0.1', '0.0.0.0']
+
+function isInsecureWs(rippledHost: string | null): boolean {
+  return (
+    Boolean(process.env.REACT_APP_INSECURE_WS) ||
+    LOCALHOST_URLS.some((url) => rippledHost?.includes(url)) ||
+    rippledHost === ''
+  )
+}
+
+function getSocket(rippledUrl: string): XrplClient {
+  const rippledHost = rippledUrl ?? process.env.REACT_APP_RIPPLED_HOST
+  const prefix = isInsecureWs(rippledHost) ? 'ws' : 'wss'
+  const wsUrls: string[] = []
+  if (rippledHost.includes(':')) {
+    wsUrls.push(`${prefix}://${rippledHost}`)
+  } else {
+    wsUrls.push.apply(wsUrls, [
+      `${prefix}://${rippledHost}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
+      `${prefix}://${rippledHost}:443`,
+    ])
+  }
+  const socket = new XrplClient(wsUrls)
+  const hasP2PSocket =
+    process.env.REACT_APP_P2P_RIPPLED_HOST != null &&
+    process.env.REACT_APP_P2P_RIPPLED_HOST !== ''
+  // @ts-ignore - will be removed eventually
+  socket.p2pSocket = hasP2PSocket
+    ? new XrplClient([
+        `${prefix}://${process.env.REACT_APP_P2P_RIPPLED_HOST}:${process.env.REACT_APP_RIPPLED_WS_PORT}`,
+      ])
+    : undefined
+  return socket
+}
+
+const SocketContext = React.createContext(undefined)
+
+export { getSocket }
+
+export default SocketContext

--- a/src/containers/shared/SocketContext.ts
+++ b/src/containers/shared/SocketContext.ts
@@ -5,7 +5,7 @@ const LOCALHOST_URLS = ['localhost', '127.0.0.1', '0.0.0.0']
 
 function isInsecureWs(rippledHost: string | null): boolean {
   return (
-    Boolean(process.env.REACT_APP_INSECURE_WS) ||
+    !!Number(process.env.REACT_APP_INSECURE_WS) ||
     LOCALHOST_URLS.some((url) => rippledHost?.includes(url)) ||
     rippledHost === ''
   )


### PR DESCRIPTION
## High Level Overview of Change

The Explorer usually uses a `wss` connection to connect to nodes. To connect to a node that doesn't have this setup, such as a node running locally, you need to switch to a `ws` connection. This PR solves that problem.

This PR also edits the sidechain URL display to include the port (this is confusing in localhost, when running multiple local nodes).

There is also a new environment variable that can be defined, when working with an external network that doesn't have SSL set up.

### Context of Change

When running a local node, you usually don't have a secure connection setup, so the `wss` connection fails.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### TypeScript/Hooks Update

N/A

## Before / After
Before:
![image](https://user-images.githubusercontent.com/8029314/194641191-2c42d2ba-c8e0-461a-b882-259d3414eebb.png)

After:
![image](https://user-images.githubusercontent.com/8029314/194641110-ffda1d0f-b744-4a09-b07a-ed5eb6985a69.png)

## Test Plan

Works locally. I was able to connect to both a local node (with a `ws` connection) and an external node (with a `wss` connection).