### PR TITLE
fix: constrain `.mask-overlay` to `.anchor-mask`

### DIFF
--- a/src/containers/shared/css/global.scss
+++ b/src/containers/shared/css/global.scss
@@ -214,6 +214,8 @@ This makes the `mask-overlay` sit on top of the `anchor-mask` and then places an
 */
 
 .anchor-mask {
+  position: relative;
+
   a {
     position: relative;
     z-index: 10;


### PR DESCRIPTION
## High Level Overview of Change

On the ledger page a transaction's .mask-overlay took up the whole page.  This was broken by #383.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before
![Screen Shot 2022-10-07 at 4 13 17 PM](https://user-images.githubusercontent.com/464895/194653284-5348c560-46a8-4f4a-b996-bba662f4f0aa.png)

## After
![Screen Shot 2022-10-07 at 4 12 05 PM](https://user-images.githubusercontent.com/464895/194653147-d5a82611-e731-42f8-9e57-3c3a14d43328.png)
