### PR TITLE
fix(css): clean up spacing on home page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
-  <div id="xrpl-explorer"></div>
+  <div class="xrpl-explorer" id="xrpl-explorer"></div>
   <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/containers/App/app.scss
+++ b/src/containers/App/app.scss
@@ -1,7 +1,7 @@
 @import '../shared/css/variables';
 
 .app {
-  position: relative;
+  flex-grow: 1;
 
   .content {
     display: flex;

--- a/src/containers/App/app.scss
+++ b/src/containers/App/app.scss
@@ -15,9 +15,6 @@
     @include for-size(desktop-up) {
       min-height: $min-height;
     }
-    @include for-size(big-desktop-up) {
-      min-height: $min-height;
-    }
   }
 
   .content,

--- a/src/containers/Footer/footer.scss
+++ b/src/containers/Footer/footer.scss
@@ -21,10 +21,6 @@
 
   .footer-link-section {
     padding-top: 40px;
-
-    @include for-size(tablet-landscape-up) {
-      padding-top: 104px;
-    }
   }
 
   .footer-section-header {
@@ -56,10 +52,6 @@
 
   .footer-branding {
     margin-top: 40px;
-
-    @include for-size(tablet-landscape-up) {
-      margin-top: 104px;
-    }
   }
 
   .logo {

--- a/src/containers/Ledger/ledger.scss
+++ b/src/containers/Ledger/ledger.scss
@@ -2,7 +2,6 @@
 
 .ledger-page {
   position: relative;
-  min-height: 600px;
 
   .loader {
     position: absolute;

--- a/src/containers/Ledgers/css/ledgers.scss
+++ b/src/containers/Ledgers/css/ledgers.scss
@@ -11,7 +11,6 @@ $ledger-width: 168px;
 }
 
 .ledgers {
-  min-height: 600px;
   justify-self: space-between;
 
   .control {

--- a/src/containers/shared/css/global.scss
+++ b/src/containers/shared/css/global.scss
@@ -19,6 +19,10 @@
   unicode-range: u+e900-e901;
 }
 
+html {
+  height: 100%;
+}
+
 body,
 input {
   padding: 0px;

--- a/src/containers/shared/css/global.scss
+++ b/src/containers/shared/css/global.scss
@@ -23,6 +23,20 @@ html {
   height: 100%;
 }
 
+body {
+  height: 100%;
+}
+
+.xrpl-explorer {
+  height: 100%;
+}
+
+.app-wrapper {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+}
+
 body,
 input {
   padding: 0px;

--- a/src/containers/shared/css/variables.scss
+++ b/src/containers/shared/css/variables.scss
@@ -7,7 +7,7 @@ $tablet-landscape-upper-boundary: 900px;
 $desktop-upper-boundary: 1200px;
 
 // Minimum height and width
-$min-height: 667px;
+$min-height: 500px;
 $min-width: 375px;
 
 // Colors


### PR DESCRIPTION
## High Level Overview of Change

This PR changes the spacing on the home page (where the ledgers scroll by). Now, if there isn't very much on the page, there won't be a scroll bar.

### Context of Change

The need for a scroll bar was more noticeable in iframes in a page I'm building for the sidechain CLI.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
![image](https://user-images.githubusercontent.com/8029314/195447057-c068ebdf-baca-40a0-af94-c4df97bad52a.png)

After:
![image](https://user-images.githubusercontent.com/8029314/195447113-6ed85d20-7990-4d69-b434-5ab1473c3878.png)

## Test Plan

Works locally.
