### PR TITLE
fix: Reduce padding of TransactionTable

### DIFF
--- a/src/containers/shared/components/TransactionTable/TransactionTable.tsx
+++ b/src/containers/shared/components/TransactionTable/TransactionTable.tsx
@@ -33,7 +33,7 @@ export const TransactionTable: TransactionTableComponent = ({
     hasAdditionalResults && <LoadMoreButton onClick={onLoadMore} />
 
   return (
-    <div className="section">
+    <>
       <ol className="transaction-table">
         <li className="transaction-li transaction-li-header">
           <div className="col-account">{t('account')}</div>
@@ -50,6 +50,6 @@ export const TransactionTable: TransactionTableComponent = ({
         )}
       </ol>
       {loading ? <Loader /> : renderLoadMore()}
-    </div>
+    </>
   )
 }

--- a/src/containers/shared/components/TransactionTable/styles.scss
+++ b/src/containers/shared/components/TransactionTable/styles.scss
@@ -217,7 +217,7 @@
 
   .transaction-li.transaction-li-header {
     display: block;
-    padding: 40px 32px 18px;
+    padding: 0 32px 18px;
     border-left-color: transparent;
     font-size: 10px;
     text-transform: uppercase;


### PR DESCRIPTION

## High Level Overview of Change

Removed top padding on transaction tables. 

### Context of Change

#398 and #402 combined to make the padding too great

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before
![Screen Shot 2022-10-12 at 4 37 01 PM](https://user-images.githubusercontent.com/464895/195453727-fb03387a-fe0b-46de-8797-a17d6e482a7f.png)
![Screen Shot 2022-10-12 at 4 35 27 PM](https://user-images.githubusercontent.com/464895/195453746-7b19054e-e9b5-4ebe-b21d-ffc7e73fe078.png)

## After
![Screen Shot 2022-10-12 at 4 36 32 PM](https://user-images.githubusercontent.com/464895/195453789-cb853ea6-cdc1-43fa-95ab-75d967e55c49.png)
![Screen Shot 2022-10-12 at 4 36 19 PM](https://user-images.githubusercontent.com/464895/195453815-57e11abb-bb6e-449c-8379-857e91fb6fdc.png)
