### PR TITLE
fix(css): wrap metrics properly at tablet size

### DIFF
--- a/src/containers/Ledgers/css/ledgerMetrics.scss
+++ b/src/containers/Ledgers/css/ledgerMetrics.scss
@@ -6,14 +6,6 @@
   background: $black;
   text-align: center;
 
-  @include for-size(tablet-landscape-up) {
-    display: flex;
-    width: calc(100% - 124px);
-    justify-content: space-between;
-    padding: 0px 12px;
-    margin: auto;
-  }
-
   @include for-size(desktop-up) {
     display: block;
     max-width: inherit;


### PR DESCRIPTION
## High Level Overview of Change

On the Ledgers page, with a width between 600px and 900px, the metrics wouldn't properly wrap, so they'd be hidden. This PR fixes that issue.

### Context of Change

Fixes #407 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
![image](https://user-images.githubusercontent.com/8029314/195460506-d91e42e3-dc55-4f81-aacf-ca0dde2ce1d2.png)

After:
![image](https://user-images.githubusercontent.com/8029314/195460451-69d682cd-db4d-43b3-b6ae-117f0490b402.png)

## Test Plan

Works locally.
