### PR TITLE
fix(tx): right align amounts in simple tab

### DIFF
--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -22,6 +22,14 @@ $subdued-color: $gray-400;
 
     .row {
       .value {
+        .amount {
+          text-align: right;
+
+          .amount-localized {
+            display: block;
+          }
+        }
+
         .currency {
           display: block;
           margin: -1px 0px -16px;


### PR DESCRIPTION
## High Level Overview of Change

This the value of `Amount` component was showing up as left aligned.

### Context of Change

This was broken by #390.  This only showed up if the amount is for an issued currency where the currency part was longer than the value.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before
<img width="1022" alt="Screen Shot 2022-10-12 at 8 11 38 PM" src="https://user-images.githubusercontent.com/464895/195476641-939fc156-a516-441f-951f-e98772e56c07.png">
<img width="1022" alt="Screen Shot 2022-10-12 at 8 11 17 PM" src="https://user-images.githubusercontent.com/464895/195476650-f967a69b-15ab-4ea2-a3ac-e33927abe40d.png">

## After
<img width="1022" alt="Screen Shot 2022-10-12 at 8 19 12 PM" src="https://user-images.githubusercontent.com/464895/195476848-9e255935-2e5a-4f42-9402-0ec398e0b816.png">
<img width="1022" alt="Screen Shot 2022-10-12 at 8 19 56 PM" src="https://user-images.githubusercontent.com/464895/195476920-274fd103-3ba7-4ea9-98c2-04cac22e7d3a.png">
