### PR TITLE
fix: ledger metrics centered instead of right-justified

### DIFF
--- a/src/containers/Ledgers/css/ledgerMetrics.scss
+++ b/src/containers/Ledgers/css/ledgerMetrics.scss
@@ -7,7 +7,6 @@
   text-align: center;
 
   @include for-size(tablet-landscape-up) {
-    display: flex;
     width: calc(100% - 124px);
     justify-content: space-between;
     padding: 0px 12px;

--- a/src/containers/Ledgers/css/ledgerMetrics.scss
+++ b/src/containers/Ledgers/css/ledgerMetrics.scss
@@ -13,11 +13,6 @@
     margin: auto;
   }
 
-  @include for-size(desktop-up) {
-    display: block;
-    max-width: inherit;
-  }
-
   .cell {
     display: inline-block;
     width: 100%;

--- a/src/containers/Ledgers/css/ledgerMetrics.scss
+++ b/src/containers/Ledgers/css/ledgerMetrics.scss
@@ -6,6 +6,14 @@
   background: $black;
   text-align: center;
 
+  @include for-size(tablet-landscape-up) {
+    display: flex;
+    width: calc(100% - 124px);
+    justify-content: space-between;
+    padding: 0px 12px;
+    margin: auto;
+  }
+
   @include for-size(desktop-up) {
     display: block;
     max-width: inherit;


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes the justification of the ledger metrics on the main page. Instead of being right-justified, it is centered (as previous).

### Context of Change

#408 changed too much, this is a fix for that.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/8029314/196785564-8c861a74-ac83-4294-b3ad-13f1233fba0b.png">

After:
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/8029314/196786265-4f5c1376-f0c1-4370-8f75-51caca33390c.png">

## Test Plan

Works locally.
