### PR TITLE
Fix ledger enter animation

### DIFF
--- a/src/containers/Ledgers/css/ledgers.scss
+++ b/src/containers/Ledgers/css/ledgers.scss
@@ -81,25 +81,34 @@ $ledger-width: 168px;
   }
 
   .ledger {
-    min-width: $ledger-width;
-    max-width: $ledger-width;
-    margin: 0 0 0 32px;
+    overflow: visible;
+    width: $ledger-width;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-left: 32px;
     animation-duration: 0.4s;
     animation-name: ledger-enter;
     white-space: normal;
 
     &:first-child {
-      margin: 0;
+      margin-left: 0;
+    }
+
+    > *{
+      min-width: $ledger-width;
+      float: right;
     }
   }
 
   @keyframes ledger-enter {
     from {
-      max-width: 0;
+      width: 0;
+      margin-left: -32px;
     }
 
     to {
-      max-width: 168px;
+      width: $ledger-width;
+      margin-left: 0;
     }
   }
 


### PR DESCRIPTION
This is a simple fix to restore and even improve the well known ledger "swipe in" animation. It was broken by https://github.com/ripple/explorer/commit/171224e97aa938dee8d02b3b38980f0390d431da in transition to a flex based layout.

This PR modifies one single stylesheet file. It removes the unpleasant jump due to non-animated margin as well.

Result:

![fixed](https://user-images.githubusercontent.com/13929820/198857469-fbba27d4-0889-48e9-b8a6-d49d288dab24.gif)
