### PR TITLE
Fix overflow on ledger animation

### DIFF
--- a/src/containers/Ledgers/css/ledgers.scss
+++ b/src/containers/Ledgers/css/ledgers.scss
@@ -75,7 +75,7 @@ $ledger-width: 168px;
     display: flex;
     padding: 0 0 40px 32px;
     margin: -45px 16px 20px;
-    overflow-x: auto;
+    overflow-x: hidden;
   }
 
   .ledger-line {


### PR DESCRIPTION
Remove the overflow (removes scrollbar) on the ledger animation screen, this is a simple one line change in the style sheet.

Currently with out fix see scroll bar
<img width="2503" alt="Screen Shot 2022-10-31 at 10 35 21" src="https://user-images.githubusercontent.com/508629/199022644-d68c89e6-e926-4d47-87bd-285aa0a45608.png">


With fix scrollbar removed
<img width="2484" alt="Screen Shot 2022-10-31 at 10 45 41" src="https://user-images.githubusercontent.com/508629/199022630-7b6b4ed4-d4fd-4fc1-9e8a-baaf82861f95.png">

Referenced issue https://github.com/ripple/explorer/issues/422