### PR TITLE
feat: enable NFTs on all networks

### DIFF
--- a/src/containers/Accounts/AccountAssetTab/AccountAssetTab.tsx
+++ b/src/containers/Accounts/AccountAssetTab/AccountAssetTab.tsx
@@ -16,9 +16,6 @@ const AccountAssetTabDisconnected = ({ account }: Props) => {
     id: string
     assetType: string
   }>()
-  const supportsNFT = ['nft_sandbox', 'devnet'].includes(
-    process.env.REACT_APP_ENVIRONMENT as string,
-  )
   const history = useHistory()
   const { t } = useTranslation()
   function switchAsset(event: ChangeEvent<HTMLInputElement>) {
@@ -27,38 +24,34 @@ const AccountAssetTabDisconnected = ({ account }: Props) => {
   if (account.deleted) return <></>
   return (
     <>
-      {supportsNFT && (
-        <div className="radio-group">
-          {assetTypes.map((type) => {
-            const fieldId = `tokens-${type}`
-            return (
-              <label
-                className={assetType === type ? 'selected' : ''}
-                htmlFor={fieldId}
-                key={type}
-              >
-                <input
-                  type="radio"
-                  id={fieldId}
-                  name="assetType"
-                  value={type}
-                  checked={assetType === type}
-                  onChange={switchAsset}
-                />{' '}
-                {t(`assets.${type}_tab_title`)}
-              </label>
-            )
-          })}
-        </div>
-      )}
-      (
+      <div className="radio-group">
+        {assetTypes.map((type) => {
+          const fieldId = `tokens-${type}`
+          return (
+            <label
+              className={assetType === type ? 'selected' : ''}
+              htmlFor={fieldId}
+              key={type}
+            >
+              <input
+                type="radio"
+                id={fieldId}
+                name="assetType"
+                value={type}
+                checked={assetType === type}
+                onChange={switchAsset}
+              />{' '}
+              {t(`assets.${type}_tab_title`)}
+            </label>
+          )
+        })}
+      </div>
       <div className="tab-body">
         {assetType === 'issued' && (
           <AccountIssuedTokenTable account={account} />
         )}
         {assetType === 'nft' && <AccountNFTTable accountId={accountId} />}
       </div>
-      )
     </>
   )
 }


### PR DESCRIPTION
## High Level Overview of Change

Remove check on account assets tab to always break out issued tokens and NFTs.

### Context of Change

With the NFT amendment becoming enabled there is no need for the check.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)