### PR TITLE
fix: unable to load account error race condition

### DIFF
--- a/src/rippled/accountState.js
+++ b/src/rippled/accountState.js
@@ -93,8 +93,8 @@ const getAccountState = (account, rippledSocket) => {
   return getAccountInfo(rippledSocket, classicAddress)
     .then((info) =>
       Promise.all([
-        getBalances(rippledSocket, classicAddress, info.ledger_index).then(
-          (data) => formatBalances(info, data),
+        getBalances(rippledSocket, classicAddress).then((data) =>
+          formatBalances(info, data),
         ),
         getAccountEscrows(rippledSocket, classicAddress, info.ledger_index),
         getAccountPaychannels(rippledSocket, classicAddress, info.ledger_index),


### PR DESCRIPTION
## High Level Overview of Change

Use set `ledger_index` to `validated` when making the `gateway_balances` call.

### Context of Change

We were sending the `ledger_index` that comes back in the `account_info` response to `gateway_balances`.  Sometimes that ledger was not available to the clio server and would send `ledgerNotFound`

```json
{"error":"lgrNotFound","error_code":21,"error_message":"ledgerNotFound","status":"error","type":"response","id":{"_WsClient":3},"request":{"command":"gateway_balances","account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn","ledger_index":75446050,"id":{"_WsClient":3}},"warnings":[{"id":2001,"message":"This is a clio server. clio only serves validated data. If you want to talk to rippled, include 'ledger_index':'current' in your request"}]}
```

![Screen Shot 2022-10-31 at 6 35 27 PM](https://user-images.githubusercontent.com/464895/199129119-1b00d093-9a32-4b8e-a06e-258d43b4e010.png)

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
