### PR TITLE
fix: only cache nft data based on token id

### DIFF
--- a/src/containers/NFT/NFTHeader/NFTHeader.tsx
+++ b/src/containers/NFT/NFTHeader/NFTHeader.tsx
@@ -46,7 +46,7 @@ export const NFTHeader = (props: Props) => {
   const rippledSocket = useContext(SocketContext)
   const [tooltip, setTooltip] = useState(null)
   const { data, isFetching: loading } = useQuery<NFTFormattedInfo>(
-    ['getNFTInfo'],
+    ['getNFTInfo', tokenId],
     async () => {
       const info = await getNFTInfo(rippledSocket, tokenId)
       return formatNFTInfo(info)

--- a/src/containers/NFT/NFTTabs/Offers.tsx
+++ b/src/containers/NFT/NFTTabs/Offers.tsx
@@ -34,7 +34,7 @@ export const Offers = (props: Props) => {
     fetchNextPage,
     hasNextPage,
   } = useInfiniteQuery(
-    [offerType],
+    [offerType, tokenId],
     ({ pageParam = '' }) =>
       fetchOffers(rippledSocket, tokenId, undefined, pageParam),
     {


### PR DESCRIPTION
## High Level Overview of Change

Switching between two nft pages would result in only the token id and minted date updating.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)