### PR TITLE
fix: improve barchart load time

### DIFF
--- a/server/routes/v1/nodes.js
+++ b/server/routes/v1/nodes.js
@@ -99,5 +99,5 @@ module.exports = (req, res) => {
   if (Date.now() - (cache.time || 0) > 60 * 1000) {
     cacheNodes()
   }
-  res.send(cache.nodes || [])
+  res.status(200).json(cache.nodes || [])
 }

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -133,10 +133,13 @@ async function cacheTokensList() {
 // Starts the caching process for bigquery
 function startCaching() {
   // Only run if on mainnet (the tokens page doesn't exist on devnet/testnet)
-  if (process.env.REACT_APP_ENVIRONMENT !== 'mainnet') {
-    return
-  }
+  // TODO: uncomment below code when token discovery is used again
+  // if (process.env.REACT_APP_ENVIRONMENT !== 'mainnet') {
+  //   return
+  // }
+  return
   // Initialize the cache
+  // eslint-disable-next-line no-unreachable -- unused code for now
   cacheTokensList()
   // Cache every TIME_INTERVAL ms (only starts after one interval)
   const intervalId = setInterval(() => cacheTokensList(), TIME_INTERVAL)
@@ -190,7 +193,7 @@ module.exports = async (req, res) => {
       await sleep(1000)
     }
 
-    return res.status(200).send({
+    return res.status(200).json({
       result: 'success',
       updated: cachedTokensList.time,
       tokens: cachedTokensList.tokens,

--- a/server/routes/v1/tokenDiscovery.js
+++ b/server/routes/v1/tokenDiscovery.js
@@ -133,13 +133,10 @@ async function cacheTokensList() {
 // Starts the caching process for bigquery
 function startCaching() {
   // Only run if on mainnet (the tokens page doesn't exist on devnet/testnet)
-  // TODO: uncomment below code when token discovery is used again
-  // if (process.env.REACT_APP_ENVIRONMENT !== 'mainnet') {
-  //   return
-  // }
-  return
+  if (process.env.REACT_APP_ENVIRONMENT !== 'mainnet') {
+    return
+  }
   // Initialize the cache
-  // eslint-disable-next-line no-unreachable -- unused code for now
   cacheTokensList()
   // Cache every TIME_INTERVAL ms (only starts after one interval)
   const intervalId = setInterval(() => cacheTokensList(), TIME_INTERVAL)

--- a/server/routes/v1/validatorReport.js
+++ b/server/routes/v1/validatorReport.js
@@ -14,5 +14,5 @@ module.exports = async (req, res) => {
   const sortedValidatorReports = validatorReports.sort((a, b) =>
     a.date > b.date ? -1 : 1,
   )
-  return res.send(sortedValidatorReports)
+  return res.status(200).json(sortedValidatorReports)
 }

--- a/server/routes/v1/validators.js
+++ b/server/routes/v1/validators.js
@@ -51,15 +51,17 @@ module.exports = (req, res) => {
     }))
 
     if (req.query.key) {
-      return res.json(
-        validatorsFormatted.find(
-          (v) =>
-            v.master_key === req.query.key || v.signing_key === req.query.key,
-        ),
-      )
+      return res
+        .status(200)
+        .json(
+          validatorsFormatted.find(
+            (v) =>
+              v.master_key === req.query.key || v.signing_key === req.query.key,
+          ),
+        )
     }
 
-    return res.send(validatorsFormatted)
+    return res.status(200).json(validatorsFormatted)
   }
 
   const validatorSummary = validators.map((v) => ({
@@ -70,8 +72,10 @@ module.exports = (req, res) => {
   }))
 
   if (req.query.unl === process.env.REACT_APP_VALIDATOR) {
-    return res.send(validatorSummary.filter((val) => val.unl === req.query.unl))
+    return res
+      .status(200)
+      .json(validatorSummary.filter((val) => val.unl === req.query.unl))
   }
 
-  return res.send(validatorSummary)
+  return res.status(200).json(validatorSummary)
 }

--- a/src/containers/Network/BarChartVersion.tsx
+++ b/src/containers/Network/BarChartVersion.tsx
@@ -122,6 +122,7 @@ const BarChartVersion = (props: Props) => {
             {stableVersion &&
               data.map((_entry, index) => (
                 <Cell
+                  key={data[index].label}
                   fill={stableColorCode(data[index].label, stableVersion)}
                 />
               ))}

--- a/src/containers/Network/UpgradeStatus.tsx
+++ b/src/containers/Network/UpgradeStatus.tsx
@@ -86,7 +86,7 @@ export const UpgradeStatus = () => {
         setUnlCount(
           resp.data.filter((validator: any) => Boolean(validator.unl)).length,
         )
-        setAggregated(aggregateData(Object.values(vList)))
+        setAggregated(aggregateData(Object.values(newValidatorList)))
       })
       .catch((e) => Log.error(e))
   }


### PR DESCRIPTION
## High Level Overview of Change

This PR improves the loading of the Upgrade Status bar chart, from ~5 seconds to almost instantaneously.

It was effectively waiting for the second `fetch` before loading the bar chart, due to a bug.

I also fixed a few other minor issues along the way, like the status codes of the Explorer backend, and adding a key to a map.

### Context of Change

The bar chart took about 5 seconds to load, despite not needing the time for processing. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

The bar chart now loads almost instantaneously.

## Test Plan

Works locally.
