### PR TITLE
fix: improve initial WS connection time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "ripple-address-codec": "^4.2.4",
         "topojson-client": "^3.0.0",
         "ws": "^7.4.2",
-        "xrpl-client": "^1.9.4"
+        "xrpl-client": "^2.0.0"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",
@@ -33194,9 +33194,9 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xrpl-client": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/xrpl-client/-/xrpl-client-1.9.4.tgz",
-      "integrity": "sha512-0+O5TbJB4GBAuZVvIrZje8VMSTTQKU8pyvuOggSmX9fhqed5c7+GGOSmKD7RWNmyQ1dZT2I70tDpzocZybtYyg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xrpl-client/-/xrpl-client-2.0.0.tgz",
+      "integrity": "sha512-A6AFw8zqUQ8/kUtwl+YHMbXFFaSeh5e6eHHohLPmnflPm1TGvVdg3xJTklvWz17G8EA5fv4nW36srIheA8apTg==",
       "dependencies": {
         "debug": "^4.1.1",
         "websocket": "^1.0.34"
@@ -58492,9 +58492,9 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xrpl-client": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/xrpl-client/-/xrpl-client-1.9.4.tgz",
-      "integrity": "sha512-0+O5TbJB4GBAuZVvIrZje8VMSTTQKU8pyvuOggSmX9fhqed5c7+GGOSmKD7RWNmyQ1dZT2I70tDpzocZybtYyg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xrpl-client/-/xrpl-client-2.0.0.tgz",
+      "integrity": "sha512-A6AFw8zqUQ8/kUtwl+YHMbXFFaSeh5e6eHHohLPmnflPm1TGvVdg3xJTklvWz17G8EA5fv4nW36srIheA8apTg==",
       "requires": {
         "debug": "^4.1.1",
         "websocket": "^1.0.34"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ripple-address-codec": "^4.2.4",
     "topojson-client": "^3.0.0",
     "ws": "^7.4.2",
-    "xrpl-client": "^1.9.4"
+    "xrpl-client": "^2.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",

--- a/server/lib/streams.js
+++ b/server/lib/streams.js
@@ -96,12 +96,13 @@ const updateMetrics = (baseFee) => {
     if (d.total_fees) {
       fees += d.total_fees
       txCount += d.txn_count ?? 0
-      ledgerCount += 1
     }
+    ledgerCount += 1
   })
   currentMetric.base_fee = Number(baseFee.toPrecision(4)).toString()
-  currentMetric.txn_sec =
-    time && txCount ? ((txCount / time) * 1000).toFixed(2) : undefined
+  currentMetric.txn_sec = time
+    ? ((txCount / time) * 1000).toFixed(2)
+    : undefined
   currentMetric.txn_ledger = ledgerCount
     ? (txCount / ledgerCount).toFixed(2)
     : undefined

--- a/src/containers/Ledgers/LedgerMetrics.jsx
+++ b/src/containers/Ledgers/LedgerMetrics.jsx
@@ -7,6 +7,7 @@ import { localizeNumber } from '../shared/utils'
 import { ReactComponent as PauseIcon } from '../shared/images/ic_pause.svg'
 import { ReactComponent as ResumeIcon } from '../shared/images/ic_play.svg'
 import './css/ledgerMetrics.scss'
+import SocketContext from '../shared/SocketContext'
 
 const DEFAULTS = {
   load_fee: '--',
@@ -132,15 +133,24 @@ class LedgerMetrics extends Component {
 
     const { tooltip } = this.state
 
+    // eslint-disable-next-line react/destructuring-assignment
+    const isOnline = this.context.getState().online
+
     return (
       <div className="metrics-control">
-        <div className="control">{this.renderPause()}</div>
-        <div className="metrics">{items}</div>
-        <Tooltip t={t} language={language} data={tooltip} />
+        {isOnline && (
+          <>
+            <div className="control">{this.renderPause()}</div>
+            <div className="metrics">{items}</div>
+            <Tooltip t={t} language={language} data={tooltip} />
+          </>
+        )}
       </div>
     )
   }
 }
+
+LedgerMetrics.contextType = SocketContext
 
 LedgerMetrics.propTypes = {
   data: PropTypes.shape({}),

--- a/src/containers/Ledgers/Ledgers.jsx
+++ b/src/containers/Ledgers/Ledgers.jsx
@@ -8,6 +8,8 @@ import Tooltip from '../shared/components/Tooltip'
 import './css/ledgers.scss'
 import { ReactComponent as SuccessIcon } from '../shared/images/success.svg'
 import DomainLink from '../shared/components/DomainLink'
+import Loader from '../shared/components/Loader'
+import SocketContext from '../shared/SocketContext'
 
 class Ledgers extends Component {
   constructor(props) {
@@ -236,20 +238,28 @@ class Ledgers extends Component {
   render() {
     const { ledgers, selected, tooltip } = this.state
     const { t, language } = this.props
+    // eslint-disable-next-line react/destructuring-assignment
+    const isOnline = this.context.getState().online
     return (
       <>
-        <div className="ledgers">
-          <div className="control">{selected && this.renderSelected()}</div>
-          <div className="ledger-line" />
-          <div className="ledger-list">
-            {ledgers.map(this.renderLedger)}{' '}
-            <Tooltip t={t} language={language} data={tooltip} />
+        {isOnline ? (
+          <div className="ledgers">
+            <div className="control">{selected && this.renderSelected()}</div>
+            <div className="ledger-line" />
+            <div className="ledger-list">
+              {ledgers.map(this.renderLedger)}{' '}
+              <Tooltip t={t} language={language} data={tooltip} />
+            </div>
           </div>
-        </div>
+        ) : (
+          <Loader />
+        )}
       </>
     )
   }
 }
+
+Ledgers.contextType = SocketContext
 
 Ledgers.propTypes = {
   ledgers: PropTypes.arrayOf(PropTypes.shape({})), // eslint-disable-line

--- a/src/containers/Ledgers/Ledgers.jsx
+++ b/src/containers/Ledgers/Ledgers.jsx
@@ -241,20 +241,20 @@ class Ledgers extends Component {
     // eslint-disable-next-line react/destructuring-assignment
     const isOnline = this.context.getState().online
     return (
-      <>
+      <div className="ledgers">
         {isOnline ? (
-          <div className="ledgers">
+          <>
             <div className="control">{selected && this.renderSelected()}</div>
             <div className="ledger-line" />
             <div className="ledger-list">
               {ledgers.map(this.renderLedger)}{' '}
               <Tooltip t={t} language={language} data={tooltip} />
-            </div>
-          </div>
+            </div>{' '}
+          </>
         ) : (
           <Loader />
         )}
-      </>
+      </div>
     )
   }
 }

--- a/src/containers/Ledgers/css/ledgers.scss
+++ b/src/containers/Ledgers/css/ledgers.scss
@@ -8,6 +8,10 @@ $ledger-width: 168px;
   flex-direction: column;
   justify-content: center;
   margin: 1% 0 auto;
+
+  .loader {
+    position: inherit;
+  }
 }
 
 .ledgers {
@@ -94,7 +98,7 @@ $ledger-width: 168px;
       margin-left: 0;
     }
 
-    > *{
+    > * {
       min-width: $ledger-width;
       float: right;
     }

--- a/src/containers/shared/SocketContext.ts
+++ b/src/containers/shared/SocketContext.ts
@@ -23,7 +23,7 @@ function getSocket(rippledUrl: string): XrplClient {
       `${prefix}://${rippledHost}:443`,
     ])
   }
-  const socket = new XrplClient(wsUrls)
+  const socket = new XrplClient(wsUrls, { tryAllNodes: true })
   const hasP2PSocket =
     process.env.REACT_APP_P2P_RIPPLED_HOST != null &&
     process.env.REACT_APP_P2P_RIPPLED_HOST !== ''

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -411,14 +411,13 @@ class Streams extends Component {
       }
       if (d.txn_count) {
         txCount += d.txn_count
-        ledgerCount += 1
       }
+      ledgerCount += 1
     })
 
     return {
       base_fee: Number(baseFee.toPrecision(4)).toString(),
-      txn_sec:
-        time && txCount ? ((txCount / time) * 1000).toFixed(2) : undefined,
+      txn_sec: time ? ((txCount / time) * 1000).toFixed(2) : undefined,
       txn_ledger: ledgerCount ? (txCount / ledgerCount).toFixed(2) : undefined,
       ledger_interval: timeCount
         ? (time / timeCount / 1000).toFixed(3)

--- a/src/containers/test/mockWsClient.js
+++ b/src/containers/test/mockWsClient.js
@@ -100,6 +100,17 @@ class MockWsClient extends EventEmitter {
     const { command } = message
     return Promise.resolve(this.responses[command]?.result)
   }
+
+  /**
+   * Mocks the `send` method on XrplClient.
+   * @param message The message to rippled.
+   * @returns a Promise result. If `this.returnError` has been set to `true`,
+   * the promise will be rejected with an empty shape.
+   */
+  // eslint-disable-next-line class-methods-use-this -- not needed for a mock
+  getState() {
+    return { online: true }
+  }
 }
 
 export default MockWsClient


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Improves the load time for the initial WS connection for networks that use `:443`
* Adds a loader on the main page when the connection is being initialized
* Improves metrics calculations, so if there are 0 transactions, the average tx/ledger and tx/sec metrics still load with 0 values.

### Context of Change

https://github.com/XRPL-Labs/xrpl-client/issues/6

A network that has a `:443` connection on `custom` will take several seconds to connect, because it has to try `:51233` first.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
![image](https://user-images.githubusercontent.com/8029314/200627256-54b1eac0-4e5e-48e7-98f8-84b5d8a3cc4e.png)

![image](https://user-images.githubusercontent.com/8029314/200628329-8d04f26b-7896-4800-8a77-1ddbd10e1df9.png)

After:
![image](https://user-images.githubusercontent.com/8029314/200627338-db5f4e3e-cfec-4c96-affc-63f3270d88a2.png)

![image](https://user-images.githubusercontent.com/8029314/200628460-38765998-ff1d-40ee-959b-8d453c19530f.png)

## Test Plan

Works locally.

## Future Tasks

Add error message when the ws fails to connect