### PR TITLE
fix: remove empty validators on Validators page

### DIFF
--- a/src/containers/Network/Validators.tsx
+++ b/src/containers/Network/Validators.tsx
@@ -46,10 +46,12 @@ export const Validators = () => {
     setVList((value: any) => {
       const newValidatorsList: any = { ...value }
       newValidations.forEach((validation: any) => {
-        newValidatorsList[validation.pubkey] = {
-          ...value[validation.pubkey],
-          ledger_index: validation.ledger_index,
-          ledger_hash: validation.ledger_hash,
+        if (value[validation.pubkey]) {
+          newValidatorsList[validation.pubkey] = {
+            ...value[validation.pubkey],
+            ledger_index: validation.ledger_index,
+            ledger_hash: validation.ledger_hash,
+          }
         }
       })
       return newValidatorsList

--- a/src/containers/Network/Validators.tsx
+++ b/src/containers/Network/Validators.tsx
@@ -46,12 +46,10 @@ export const Validators = () => {
     setVList((value: any) => {
       const newValidatorsList: any = { ...value }
       newValidations.forEach((validation: any) => {
-        if (value[validation.pubkey]) {
-          newValidatorsList[validation.pubkey] = {
-            ...value[validation.pubkey],
-            ledger_index: validation.ledger_index,
-            ledger_hash: validation.ledger_hash,
-          }
+        newValidatorsList[validation.pubkey] = {
+          ...value[validation.pubkey],
+          ledger_index: validation.ledger_index,
+          ledger_hash: validation.ledger_hash,
         }
       })
       return newValidatorsList

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -295,9 +295,11 @@ class Streams extends Component {
         unl: vList && vList[data.pubkey] && vList[data.pubkey].unl,
       })
 
-      validators[data.pubkey] = data
-      this.updateLedgers(ledgers)
-      this.updateValidators(validators)
+      if (vList[data.pubkey]) {
+        validators[data.pubkey] = data
+        this.updateLedgers(ledgers)
+        this.updateValidators(validators)
+      }
       return { ledgers, validators, maxLedger }
     })
   }

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -295,11 +295,9 @@ class Streams extends Component {
         unl: vList && vList[data.pubkey] && vList[data.pubkey].unl,
       })
 
-      if (vList[data.pubkey] !== undefined) {
-        validators[data.pubkey] = data
-        this.updateLedgers(ledgers)
-        this.updateValidators(validators)
-      }
+      validators[data.pubkey] = data
+      this.updateLedgers(ledgers)
+      this.updateValidators(validators)
       return { ledgers, validators, maxLedger }
     })
   }

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -295,7 +295,7 @@ class Streams extends Component {
         unl: vList && vList[data.pubkey] && vList[data.pubkey].unl,
       })
 
-      if (vList[data.pubkey]) {
+      if (vList[data.pubkey] !== undefined) {
         validators[data.pubkey] = data
         this.updateLedgers(ledgers)
         this.updateValidators(validators)


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->
There are a few empty validators that has no data. Need to investigate where they come from and remove them.

Cause: the `validations` stream from `Streams` component returns some validations with `pubkey` not in the validators key list.
Solution: only update the validators list (`vList`) and validation list (`validations`) with valid validation's `pubkey`.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

### Before
Explorer Validators page has empty validators and inconsistent validators count.
![Screenshot 2022-11-08 at 4 02 19 PM](https://user-images.githubusercontent.com/71317875/202006281-fecb3114-a0b0-4567-be8c-2c7b2d282a3a.png)

### After
Those empty validators are not added to the table and validators count stay consistent.

![Screenshot 2022-11-15 at 2 18 14 PM](https://user-images.githubusercontent.com/71317875/202006572-97299926-bd78-4ba2-a355-30cdee2ff884.png)
