### PR TITLE
fix: fix display length of custom network input

### DIFF
--- a/src/containers/CustomNetworkHome/index.scss
+++ b/src/containers/CustomNetworkHome/index.scss
@@ -46,9 +46,10 @@
       }
 
       input {
-        width: auto;
+        width: 50%;
+        min-width: 300px;
         height: 40px;
-        padding: 8px 25% 8px 16px;
+        padding: 8px 16px;
         border: none;
         margin: 10px 16px;
         background-color: $gray-900;


### PR DESCRIPTION
## High Level Overview of Change

The input textbox on custom.xrpl.org cut off early (see screenshots below). This PR fixes it.

### Context of Change

Noticed by @ckniffen 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

Before:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/8029314/203128667-324d55e4-8828-41fc-b6ea-eec064285984.png">

After:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/8029314/203128770-07597213-4383-4398-9e5b-92a7839baa36.png">

## Test Plan

Works locally.
