### PR TITLE
test: clean up duplicate QueryClient

### DIFF
--- a/src/containers/Accounts/AccountNFTTable/test/AccountNFTtable.test.jsx
+++ b/src/containers/Accounts/AccountNFTTable/test/AccountNFTtable.test.jsx
@@ -7,7 +7,7 @@ import { getAccountNFTs } from '../../../../rippled/lib/rippled'
 import { AccountNFTTable } from '../AccountNFTTable'
 import i18n from '../../../../i18nTestConfig'
 import { EmptyMessageTableRow } from '../../../shared/EmptyMessageTableRow'
-import { queryClient } from '../../../shared/utils'
+import { testQueryClient } from '../../../test/QueryClient'
 
 jest.mock('../../../../rippled/lib/rippled', () => ({
   __esModule: true,
@@ -41,7 +41,7 @@ describe('AccountNFTTable component', () => {
 
   const createWrapper = () =>
     mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <BrowserRouter>
           <I18nextProvider i18n={i18n}>
             <AccountNFTTable accountId={TEST_ACCOUNT_ID} />

--- a/src/containers/Accounts/AccountTransactionTable/test/AccountTransactionTable.test.js
+++ b/src/containers/Accounts/AccountTransactionTable/test/AccountTransactionTable.test.js
@@ -7,7 +7,7 @@ import i18n from '../../../../i18nTestConfig'
 import { AccountTransactionTable } from '../index'
 import TEST_TRANSACTIONS_DATA from './mockTransactions.json'
 import { getAccountTransactions } from '../../../../rippled'
-import { queryClient } from '../../../shared/QueryClient'
+import { testQueryClient } from '../../../test/QueryClient'
 
 jest.mock('../../../../rippled', () => ({
   __esModule: true,
@@ -20,13 +20,6 @@ function flushPromises() {
   return new Promise((resolve) => setImmediate(resolve))
 }
 
-queryClient.setDefaultOptions({
-  queries: {
-    ...queryClient.defaultQueryOptions(),
-    cacheTime: 0,
-  },
-})
-
 describe('AccountTransactionsTable container', () => {
   const createWrapper = (
     getAccountTransactionsImpl = () =>
@@ -38,7 +31,7 @@ describe('AccountTransactionsTable container', () => {
   ) => {
     getAccountTransactions.mockImplementation(getAccountTransactionsImpl)
     return mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <I18nextProvider i18n={i18n}>
           <Router>
             <AccountTransactionTable

--- a/src/containers/Accounts/test/index.test.js
+++ b/src/containers/Accounts/test/index.test.js
@@ -12,7 +12,7 @@ import Account from '../index'
 import AccountHeader from '../AccountHeader'
 import { AccountTransactionTable } from '../AccountTransactionTable'
 import mockAccountState from './mockAccountState.json'
-import { queryClient } from '../../shared/utils'
+import { testQueryClient } from '../../test/QueryClient'
 
 describe('Account container', () => {
   const TEST_ACCOUNT_ID = 'rTEST_ACCOUNT'
@@ -22,7 +22,7 @@ describe('Account container', () => {
   const createWrapper = (state = {}) => {
     const store = mockStore({ ...initialState, ...state })
     return mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <I18nextProvider i18n={i18n}>
           <Provider store={store}>
             <MemoryRouter initialEntries={[`accounts/${TEST_ACCOUNT_ID}`]}>

--- a/src/containers/Ledgers/test/LedgersPage.test.js
+++ b/src/containers/Ledgers/test/LedgersPage.test.js
@@ -13,11 +13,11 @@ import Ledgers from '../index'
 import { initialState } from '../../../rootReducer'
 import SocketContext from '../../shared/SocketContext'
 import BaseMockWsClient from '../../test/mockWsClient'
-import { queryClient } from '../../shared/utils'
 import prevLedgerMessage from './mock/prevLedger.json'
 import ledgerMessage from './mock/ledger.json'
 import validationMessage from './mock/validation.json'
 import rippledResponses from './mock/rippled.json'
+import { testQueryClient } from '../../test/QueryClient'
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -70,7 +70,7 @@ describe('Ledgers Page container', () => {
     const store = mockStore({ ...initialState })
 
     return mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <Router>
           <I18nextProvider i18n={i18n}>
             <Provider store={store}>

--- a/src/containers/Network/test/nodes.test.js
+++ b/src/containers/Network/test/nodes.test.js
@@ -11,7 +11,7 @@ import { initialState } from '../../App/reducer'
 import i18n from '../../../i18nTestConfig'
 import Network from '../index'
 import mockNodes from './mockNodes.json'
-import { queryClient } from '../../shared/utils'
+import { testQueryClient } from '../../test/QueryClient'
 
 /* eslint-disable react/jsx-props-no-spreading */
 const middlewares = [thunk]
@@ -21,7 +21,7 @@ const store = mockStore({ app: initialState })
 describe('Nodes Page container', () => {
   const createWrapper = (props = {}) =>
     mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <Router>
           <I18nextProvider i18n={i18n}>
             <Provider store={store}>

--- a/src/containers/Network/test/validators.test.js
+++ b/src/containers/Network/test/validators.test.js
@@ -15,7 +15,7 @@ import mockValidators from './mockValidators.json'
 import validationMessage from './mockValidation.json'
 import SocketContext from '../../shared/SocketContext'
 import MockWsClient from '../../test/mockWsClient'
-import { queryClient } from '../../shared/utils'
+import { testQueryClient } from '../../test/QueryClient'
 
 /* eslint-disable react/jsx-props-no-spreading */
 const middlewares = [thunk]
@@ -29,7 +29,7 @@ describe('Validators Tab container', () => {
   let client
   const createWrapper = (props = {}) =>
     mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <Router>
           <I18nextProvider i18n={i18n}>
             <Provider store={store}>

--- a/src/containers/Token/TokenTransactionTable/test/TokenTransactionTable.test.js
+++ b/src/containers/Token/TokenTransactionTable/test/TokenTransactionTable.test.js
@@ -8,7 +8,7 @@ import { TokenTransactionTable } from '../index'
 import TEST_TRANSACTIONS_DATA from '../../../Accounts/AccountTransactionTable/test/mockTransactions.json'
 
 import { getAccountTransactions } from '../../../../rippled'
-import { queryClient } from '../../../shared/QueryClient'
+import { testQueryClient } from '../../../test/QueryClient'
 
 jest.mock('../../../../rippled', () => ({
   __esModule: true,
@@ -22,13 +22,6 @@ function flushPromises() {
   return new Promise((resolve) => setImmediate(resolve))
 }
 
-queryClient.setDefaultOptions({
-  queries: {
-    ...queryClient.defaultQueryOptions(),
-    cacheTime: 0,
-  },
-})
-
 describe('TokenTransactionsTable container', () => {
   const createWrapper = (
     getAccountTransactionsImpl = () =>
@@ -39,7 +32,7 @@ describe('TokenTransactionsTable container', () => {
   ) => {
     getAccountTransactions.mockImplementation(getAccountTransactionsImpl)
     return mount(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={testQueryClient}>
         <I18nextProvider i18n={i18n}>
           <Router>
             <TokenTransactionTable

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -180,18 +180,6 @@ export const normalizeLanguage = (lang) => {
   return undefined
 }
 
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      cacheTime: 0,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      refetchOnMount: false,
-      retry: false,
-    },
-  },
-})
-
 // Document: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat
 export const localizeNumber = (num, lang = 'en-US', options = {}) => {
   const number = Number.parseFloat(num)

--- a/src/containers/test/QueryClient.ts
+++ b/src/containers/test/QueryClient.ts
@@ -1,0 +1,10 @@
+import { queryClient } from '../shared/QueryClient'
+
+queryClient.setDefaultOptions({
+  queries: {
+    ...queryClient.defaultQueryOptions(),
+    cacheTime: 0,
+  },
+})
+
+export { queryClient as testQueryClient }


### PR DESCRIPTION
## High Level Overview of Change

This creates a testQueryClient that has caching turned off to prevent caching between tests. Previously several of the tests manually set cacheTime to 0.

### Context of Change

The two queryClient definitions were created in competing PRs.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)