### PR TITLE
ci: parallelize linting and tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -114,4 +114,6 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
-      - run: npm run build
+      - run: |
+          npm rebuild
+          npm run build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -114,4 +114,4 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
-      - run: npm run build
+      - run: CI=false npm run build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -114,4 +114,5 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
+        # TODO: remove `CI=false` once all the warnings are fixed
       - run: CI=false npm run build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -114,6 +114,4 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
-      - run: |
-          npm rebuild
-          npm run build
+      - run: npm run build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,12 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Setup npm version 8
-        id: npm8
-        run: |
-          npm --version
-          npm i -g npm@8 --registry=https://registry.npmjs.org
-
       - name: Cache node modules
         id: cache-nodemodules
         uses: actions/cache@v2
@@ -62,12 +56,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Setup npm version 8
-        id: npm8
-        run: |
-          npm --version
-          npm i -g npm@8 --registry=https://registry.npmjs.org
 
       - name: Cache node modules
         id: cache-nodemodules
@@ -108,12 +96,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Setup npm version 8
-        id: npm8
-        run: |
-          npm --version
-          npm i -g npm@8 --registry=https://registry.npmjs.org
 
       - name: Cache node modules
         id: cache-nodemodules

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  lint:
     runs-on: ubuntu-latest
 
     strategy:
@@ -27,6 +27,7 @@ jobs:
       - name: Setup npm version 8
         id: npm8
         run: |
+          npm --version
           npm i -g npm@8 --registry=https://registry.npmjs.org
 
       - name: Cache node modules
@@ -46,7 +47,46 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
-      - run: npm run test:all
+      - run: npm run lint:ci
+
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup npm version 8
+        id: npm8
+        run: |
+          npm --version
+          npm i -g npm@8 --registry=https://registry.npmjs.org
+
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: ${{ matrix.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ matrix.node-version }}-build-${{ env.cache-name }}-
+            ${{ matrix.node-version }}-build-
+
+      - name: Install Dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm install
+
+      - run: npm run test:ci
         env:
           REACT_APP_VALIDATOR: vl.ripple.com
           REACT_APP_RIPPLED_WS_PORT: 51233

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - run: npm run lint:ci
 
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -94,3 +94,42 @@ jobs:
           REACT_APP_MAINNET_LINK: mainnet.example.com
           REACT_APP_TESTNET_LINK: testnet.example.com
           REACT_APP_CUSTOMNETWORK_LINK: custom.example.com
+
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup npm version 8
+        id: npm8
+        run: |
+          npm --version
+          npm i -g npm@8 --registry=https://registry.npmjs.org
+
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: ${{ matrix.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ matrix.node-version }}-build-${{ env.cache-name }}-
+            ${{ matrix.node-version }}-build-
+
+      - name: Install Dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm install
+
+      - run: npm run build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -114,5 +114,4 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
-        # TODO: remove `CI=false` once all the warnings are fixed
-      - run: CI=false npm run build
+      - run: npm run build

--- a/build-non-split.js
+++ b/build-non-split.js
@@ -48,3 +48,4 @@ config.plugins.push(
     }
   }),
 )
+config.externals = ['dtrace-provider', 'fs']

--- a/src/containers/Transactions/index.jsx
+++ b/src/containers/Transactions/index.jsx
@@ -44,23 +44,24 @@ const Transaction = (props) => {
   const { t } = useTranslation()
   const { actions, data, loading } = props
   const rippledSocket = useContext(SocketContext)
+  const hash = data.raw ? data.raw.hash : undefined
+  const short = identifier.substr(0, 8)
+  document.title = `${t('xrpl_explorer')} | ${t(
+    'transaction_short',
+  )} ${short}...`
 
   useEffect(() => {
-    const hash = data.raw ? data.raw.hash : undefined
-    const short = identifier.substr(0, 8)
-
-    document.title = `${t('xrpl_explorer')} | ${t(
-      'transaction_short',
-    )} ${short}...`
     analytics(ANALYTIC_TYPES.pageview, {
       title: 'Transaction',
       path: `/transactions/:hash/${tab}`,
     })
+  }, [identifier, data, tab])
 
+  useEffect(() => {
     if (identifier && identifier !== hash) {
       actions.loadTransaction(identifier, rippledSocket)
     }
-  }, [identifier])
+  }, [hash, identifier, actions, rippledSocket])
 
   function renderSummary() {
     const type = data.raw.tx.TransactionType

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import { QueryClient } from 'react-query'
 import { getQuorum, getNegativeUNL } from '../../rippled'
 import Log from './log'
 


### PR DESCRIPTION
## High Level Overview of Change

This PR splits linting, testing, and building into 3 separate Github Actions. Previously, building wasn't tested at all. This makes CI run faster, since it's now parallelized, saving up to about a minute of time.

### Context of Change

Faster CI

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.
