### PR TITLE
fix: fix custom network legacy redirects

### DIFF
--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -48,14 +48,14 @@ const App = (props) => {
   const urlLink = rippledUrl ? `/${rippledUrl}` : ''
 
   /* START: Map legacy routes to new routes */
-  if (location.hash && location.pathname === '/') {
+  if (location.hash && location.pathname === `${urlLink}/`) {
     if (location.hash.indexOf('#/transactions/') === 0) {
       const identifier = location.hash.split('#/transactions/')[1]
-      return <Redirect to={`/transactions/${identifier}`} />
+      return <Redirect to={`${urlLink}/transactions/${identifier}`} />
     }
     if (location.hash.indexOf('#/graph/') === 0) {
       const identifier = location.hash.split('#/graph/')[1]
-      return <Redirect to={`/accounts/${identifier}`} />
+      return <Redirect to={`${urlLink}/accounts/${identifier}`} />
     }
   }
   /* END: Map legacy routes to new routes */

--- a/src/containers/Network/test/upgradeStatus.test.js
+++ b/src/containers/Network/test/upgradeStatus.test.js
@@ -37,7 +37,7 @@ describe('UpgradeStatus test functions', () => {
     },
   ]
 
-  it('aggregarteData handle edge case', () => {
+  it('aggregateData handle edge case', () => {
     expect(aggregateData(undefinedData)).toEqual([
       { count: 1, label: '1.9.4', value: 100 },
     ])


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

URL redirects weren't working for legacy URLs.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

I couldn't figure out how to add a test for this. Works locally.
