### PR TITLE
fix: fix typo in test that made it not run

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,22 +52,22 @@
         "**/test/*.json": true
     },
     "cSpell.words": [
-        "CUSTOMNETWORK",
-        "Decomp",
-        "Hant",
-        "CUSTOMNETWORK",
-        "MILLIS",
-        "NFTSANDBOX",
         "camelcase",
         "chopa",
         "chopb",
         "cimode",
+        "CUSTOMNETWORK",
+        "Decomp",
         "fakenode",
+        "Hant",
         "healthz",
         "hexbin",
         "middlewares",
+        "MILLIS",
         "moxios",
+        "NFTSANDBOX",
         "pageview",
+        "paychannels",
         "paystrings",
         "topojson"
     ]

--- a/src/containers/Accounts/AccountHeader/test/actions.test.js
+++ b/src/containers/Accounts/AccountHeader/test/actions.test.js
@@ -41,10 +41,12 @@ describe('AccountHeader Actions', () => {
         flags: [],
         balance: '123456000',
         gravatar: undefined,
+        nftMinter: undefined,
         previousTxn:
           '6B6F2CA1633A22247058E988372BA9EFFFC5BF10212230B67341CA32DC9D4A82',
         previousLedger: 68990183,
       },
+      deleted: false,
       balances: { XRP: 123.456 },
       signerList: undefined,
       tokens: [],
@@ -66,7 +68,7 @@ describe('AccountHeader Actions', () => {
       })
   })
 
-  fit('should dispatch correct actions on ripple account with tokens', () => {
+  it('should dispatch correct actions on account with tokens', () => {
     client.addResponses(actWithTokens)
     const expectedData = {
       account: 'rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY',
@@ -194,10 +196,12 @@ describe('AccountHeader Actions', () => {
         flags: [],
         balance: '123456000',
         gravatar: undefined,
+        nftMinter: undefined,
         previousTxn:
           '6B6F2CA1633A22247058E988372BA9EFFFC5BF10212230B67341CA32DC9D4A82',
         previousLedger: 68990183,
       },
+      deleted: false,
       balances: { XRP: 123.456 },
       signerList: undefined,
       tokens: [],
@@ -242,7 +246,7 @@ describe('AccountHeader Actions', () => {
       })
   })
 
-  it('should dispatch correct actions on ripple address not found', () => {
+  it('should dispatch correct actions on address not found', () => {
     const expectedActions = [
       { type: actionTypes.START_LOADING_ACCOUNT_STATE },
       { type: actionTypes.FINISHED_LOADING_ACCOUNT_STATE },
@@ -261,7 +265,7 @@ describe('AccountHeader Actions', () => {
       })
   })
 
-  it('should dispatch correct actions on invalid ripple address', () => {
+  it('should dispatch correct actions on invalid address', () => {
     const expectedActions = [
       {
         type: actionTypes.ACCOUNT_STATE_LOAD_FAIL,

--- a/src/containers/Accounts/AccountHeader/test/actions.test.js
+++ b/src/containers/Accounts/AccountHeader/test/actions.test.js
@@ -257,6 +257,7 @@ describe('AccountHeader Actions', () => {
       },
     ]
     client.addResponse('account_info', { result: actNotFound })
+    client.addResponse('account_tx', { result: actNotFound })
     const store = mockStore({ news: initialState })
     return store
       .dispatch(actions.loadAccountState(TEST_ADDRESS, client))


### PR DESCRIPTION
## High Level Overview of Change

One of the tests was set up as `fit(...)` instead of `it(...)`, so it wasn't actually running.

### Context of Change

See above.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

The test now runs and CI passes.
