### PR TITLE
fix: fix validator pubkey conflict

### DIFF
--- a/src/containers/Ledgers/Ledgers.jsx
+++ b/src/containers/Ledgers/Ledgers.jsx
@@ -220,7 +220,7 @@ class Ledgers extends Component {
     const partial = v.partial ? <div className="partial" /> : null
     return (
       <div
-        key={v.pubkey}
+        key={`${v.pubkey}_${v.time}`}
         role="button"
         tabIndex={i}
         className={className}

--- a/src/containers/Ledgers/Ledgers.jsx
+++ b/src/containers/Ledgers/Ledgers.jsx
@@ -220,7 +220,7 @@ class Ledgers extends Component {
     const partial = v.partial ? <div className="partial" /> : null
     return (
       <div
-        key={`${v.pubkey}_${v.time}`}
+        key={`${v.pubkey}_${v.cookie}`}
         role="button"
         tabIndex={i}
         className={className}

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -219,6 +219,7 @@ class Streams extends Component {
         pubkey,
         partial: !data.full,
         time: (data.signing_time + EPOCH_OFFSET) * 1000,
+        cookie: data.cookie,
       }
     }
 
@@ -294,6 +295,7 @@ class Streams extends Component {
         partial: data.partial,
         time: data.time,
         unl: vList && vList[data.pubkey] && vList[data.pubkey].unl,
+        cookie: data.cookie,
       })
 
       validators[data.pubkey] = data


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes the key conflict issue that occurs on the Home page. 

Fixes #208

### Context of Change

I inspected the cookies of the two validations and they were always different.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

The error no longer shows up in the console.

## Test Plan

Works locally.
