### PR TITLE
refactor: remove bunyan from the frontend build

### DIFF
--- a/src/rippled/lib/logger.js
+++ b/src/rippled/lib/logger.js
@@ -1,22 +1,16 @@
-import bunyan from 'bunyan'
+/* eslint-disable no-console -- logging file */
+// TODO: refactor this file to use the npm module `debug` which is already used elsewhere
+// and send logs in prod to the backend
 
-const log = (options) => {
-  const logger = bunyan.createLogger(options)
-
-  return {
-    info: (...args) => {
-      logger.info(...args)
-    },
-    warn: (...args) => {
-      logger.warn(...args)
-    },
-    error: (...args) => {
-      logger.error(...args)
-    },
-    debug: (...args) => {
-      logger.debug(...args)
-    },
-  }
+const logMessage = (type, options, message) => {
+  console[type]({ ...options, message })
 }
+
+const log = (options) => ({
+  info: (message) => logMessage('info', options, message),
+  warn: (message) => logMessage('warn', options, message),
+  error: (message) => logMessage('error', options, message),
+  debug: (message) => logMessage('debug', options, message),
+})
 
 export default log


### PR DESCRIPTION
## High Level Overview of Change

It reduces the build by 29k (gzipped) and fixed bunyan not being compatible with vite.

Related to #360 and was pulled out of the the vite PR(#509)

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
