### PR TITLE
fix(websocket): try connecting to sockets one at a time

### DIFF
--- a/src/containers/shared/SocketContext.tsx
+++ b/src/containers/shared/SocketContext.tsx
@@ -23,7 +23,7 @@ function getSocket(rippledUrl?: string): XrplClient {
       `${prefix}://${rippledHost}:443`,
     ])
   }
-  const socket = new XrplClient(wsUrls, { tryAllNodes: true })
+  const socket = new XrplClient(wsUrls)
   const hasP2PSocket =
     process.env.REACT_APP_P2P_RIPPLED_HOST != null &&
     process.env.REACT_APP_P2P_RIPPLED_HOST !== ''

--- a/src/containers/shared/test/SocketContext.test.ts
+++ b/src/containers/shared/test/SocketContext.test.ts
@@ -25,11 +25,10 @@ describe('getSocket', () => {
 
     it('should instantiate with environment variables', () => {
       const client = getSocket()
-      expect(XrplClient).toHaveBeenNthCalledWith(
-        1,
-        ['wss://somewhere.com:51233', 'wss://somewhere.com:443'],
-        { tryAllNodes: true },
-      )
+      expect(XrplClient).toHaveBeenNthCalledWith(1, [
+        'wss://somewhere.com:51233',
+        'wss://somewhere.com:443',
+      ])
 
       expect(XrplClient).toHaveBeenNthCalledWith(2, [
         'wss://cli-somewhere.com:51233',
@@ -42,11 +41,10 @@ describe('getSocket', () => {
       process.env.REACT_APP_INSECURE_WS = '1'
 
       const client = getSocket()
-      expect(XrplClient).toHaveBeenNthCalledWith(
-        1,
-        ['ws://somewhere.com:51233', 'ws://somewhere.com:443'],
-        { tryAllNodes: true },
-      )
+      expect(XrplClient).toHaveBeenNthCalledWith(1, [
+        'ws://somewhere.com:51233',
+        'ws://somewhere.com:443',
+      ])
 
       expect(XrplClient).toHaveBeenNthCalledWith(2, [
         'ws://cli-somewhere.com:51233',
@@ -71,9 +69,7 @@ describe('getSocket', () => {
 
     it('should use ignore REACT_APP_RIPPLED_WS_PORT when supplied entry point has a port', () => {
       const client = getSocket('hello.com:4444')
-      expect(XrplClient).toHaveBeenNthCalledWith(1, ['wss://hello.com:4444'], {
-        tryAllNodes: true,
-      })
+      expect(XrplClient).toHaveBeenNthCalledWith(1, ['wss://hello.com:4444'])
 
       expect((client as any).p2pSocket).not.toBeDefined()
     })
@@ -81,20 +77,17 @@ describe('getSocket', () => {
       process.env.REACT_APP_INSECURE_WS = '1'
 
       const client = getSocket('hello.com:4444')
-      expect(XrplClient).toHaveBeenNthCalledWith(1, ['ws://hello.com:4444'], {
-        tryAllNodes: true,
-      })
+      expect(XrplClient).toHaveBeenNthCalledWith(1, ['ws://hello.com:4444'])
 
       expect((client as any).p2pSocket).not.toBeDefined()
     })
 
     it('should use ws when supplied entry is for a localhost', () => {
       const client = getSocket('localhost')
-      expect(XrplClient).toHaveBeenNthCalledWith(
-        1,
-        ['ws://localhost:51233', 'ws://localhost:443'],
-        { tryAllNodes: true },
-      )
+      expect(XrplClient).toHaveBeenNthCalledWith(1, [
+        'ws://localhost:51233',
+        'ws://localhost:443',
+      ])
 
       expect((client as any).p2pSocket).not.toBeDefined()
     })


### PR DESCRIPTION
## High Level Overview of Change

Because of https://github.com/XRPL-Labs/xrpl-client/issues/9 connections wouldn't continue retrying.  Rolling back tryAllNodes till it can be further investigated.

Related to #542

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)