### PR TITLE
bugfix for meta parser - no crash when no amm node

### DIFF
--- a/src/containers/shared/components/Transaction/AMMDeposit/test/AMMDeposit.test.tsx
+++ b/src/containers/shared/components/Transaction/AMMDeposit/test/AMMDeposit.test.tsx
@@ -9,6 +9,7 @@ import depositUSD from './mock_data/deposit_usd.json'
 import depositXRP from './mock_data/deposit_xrp.json'
 import depositEprice from './mock_data/deposit_eprice.json'
 import depositNonXRP from './mock_data/deposit_nonxrp.json'
+import depositFail from './mock_data/deposit_fail.json'
 
 describe('AMM Deposit Tests', () => {
   const createWrapper = createSimpleWrapperFactory(Simple)
@@ -94,6 +95,15 @@ describe('AMM Deposit Tests', () => {
       'account_id',
       'rEJ1X5BoSmHqa5h6TSVvYrHAzFmyxGqNic',
     )
+    wrapper.unmount()
+  })
+
+  it('deposit shouldnt crash with tx that changes fee', () => {
+    const wrapper = createWrapper(depositFail)
+    console.log(wrapper.debug())
+    expectSimpleRowNotToExist(wrapper, 'asset1')
+    expectSimpleRowNotToExist(wrapper, 'asset2')
+    expectSimpleRowNotToExist(wrapper, 'account_id')
     wrapper.unmount()
   })
 })

--- a/src/containers/shared/components/Transaction/AMMDeposit/test/mock_data/deposit_fail.json
+++ b/src/containers/shared/components/Transaction/AMMDeposit/test/mock_data/deposit_fail.json
@@ -1,0 +1,45 @@
+{
+  "tx": {
+  "Account": "rhmfYgnWbKKwYNJbh3iysPHbz7aparZ1qd",
+  "Amount": "100000000",
+  "Asset": {
+    "currency": "XRP"
+  },
+  "Asset2": {
+    "currency": "USD",
+    "issuer": "rA3nNmhWKRZvcsA89DxTRbV62JiaSZWdy"
+  },
+  "Fee": "10",
+  "Flags": 524288,
+  "Sequence": 113545,
+  "SigningPubKey": "031E3709F92AF9138B63CCDEC7357E3779762F3FB3BB56F6966D7040644B0E179C",
+  "TransactionType": "AMMWithdraw",
+  "TxnSignature": "3044022079422294399EE1A47EB35C018CD7775E074E51BB161E005E09754243FBDA58B902203775B497F7D2993F4BA0DAC4F9E8362BEB583D261C6F4E043303451B70942428",
+  "date": "2023-01-18T01:20:21Z"
+},
+  "meta":{
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rhmfYgnWbKKwYNJbh3iysPHbz7aparZ1qd",
+            "Balance": "41057652006",
+            "Flags": 0,
+            "OwnerCount": 1,
+            "Sequence": 113546
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "1E47D3574E19E3D519D57FF5B3A6EE7622A5998A82DF170C440C8CB7AA0015E1",
+          "PreviousFields": {
+            "Balance": "41057652016",
+            "Sequence": 113545
+          },
+          "PreviousTxnID": "C7B058C67F97CF7C5F8B135BFF702FFE320130CB9516422BA82256D99E07F9F0",
+          "PreviousTxnLgrSeq": 116474
+        }
+      }
+    ],
+    "TransactionIndex": 0,
+    "TransactionResult": "tecAMM_BALANCE"
+  }
+}

--- a/src/containers/shared/metaParser.tsx
+++ b/src/containers/shared/metaParser.tsx
@@ -19,7 +19,10 @@ Gets the AMM account ID
 export function getAMMAccountID(meta: any) {
   const account = findNodes(meta, LedgerEntryTypes.AMM)[0]
 
-  return account.FinalFields?.AMMAccount || account.NewFields?.AMMAccount
+  if (account)
+    return account.FinalFields?.AMMAccount || account.NewFields?.AMMAccount
+
+  return undefined
 }
 
 export function getLPTokenAmount(meta: any) {


### PR DESCRIPTION
##

Bug fix for meta parser -  returns undefined if no amm node

added unit test to ammdeposit