### PR TITLE
chore(deps): bump nodemon from 2.0.9 to 2.0.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "lint-staged": "^13.0.3",
         "mock-socket": "^9.1.5",
         "moxios": "^0.4.0",
-        "nodemon": "^2.0.9",
+        "nodemon": "^2.0.20",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "react-error-overlay": "6.0.9",
@@ -4614,14 +4614,6 @@
       "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
       "dev": true
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "0.14.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "dev": true,
@@ -4660,17 +4652,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -5373,54 +5354,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.0.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-colors": {
@@ -6618,149 +6551,6 @@
       "version": "1.0.0",
       "license": "ISC"
     },
-    "node_modules/boxen": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/camelcase": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/boxen/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/boxen/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/boxen/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/boxen/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/string-width": {
-      "version": "4.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/boxen/node_modules/type-fest": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -6995,53 +6785,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "4.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -7344,17 +7087,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "dev": true,
@@ -7462,22 +7194,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      }
-    },
-    "node_modules/clone-response/node_modules/mimic-response": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/clsx": {
@@ -7614,74 +7330,6 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
-    },
-    "node_modules/configstore": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/configstore/node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/configstore/node_modules/make-dir": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/configstore/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/configstore/node_modules/unique-string": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/configstore/node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.10",
@@ -8367,14 +8015,6 @@
         "lodash._bindcallback": "^3.0.0"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "license": "MIT"
@@ -8387,11 +8027,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/define-properties": {
       "version": "1.1.4",
@@ -8625,17 +8260,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dotenv": {
       "version": "16.0.3",
       "license": "BSD-2-Clause",
@@ -8659,11 +8283,6 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/duplexer3": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/duplexify": {
       "version": "4.1.1",
@@ -8730,11 +8349,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -9070,14 +8684,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-goat": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/escape-html": {
@@ -11217,25 +10823,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/global-dirs": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "1.3.7"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/global-dirs/node_modules/ini": {
-      "version": "1.3.7",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "license": "MIT",
@@ -11336,46 +10923,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "9.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/got/node_modules/decompress-response": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/got/node_modules/mimic-response": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/graceful-fs": {
@@ -11529,14 +11076,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/has-yarn": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hash-base": {
       "version": "3.1.0",
       "license": "MIT",
@@ -11639,12 +11178,6 @@
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -11813,14 +11346,6 @@
       "version": "4.0.0",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/import-lazy": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/import-local": {
       "version": "3.0.2",
@@ -12204,29 +11729,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-installed-globally": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^2.0.1",
-        "is-path-inside": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-installed-globally/node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-nan": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -12251,14 +11753,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-npm": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-number": {
@@ -12292,14 +11786,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -12432,11 +11918,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-yarn-global": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -18684,11 +18165,6 @@
         "bignumber.js": "^9.0.0"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true,
@@ -18769,14 +18245,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/keyv": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "dev": true,
@@ -18810,17 +18278,6 @@
       "license": "MIT",
       "dependencies": {
         "language-subtag-registry": "~0.3.2"
-      }
-    },
-    "node_modules/latest-version": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "package-json": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/left-pad": {
@@ -19538,14 +18995,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -20115,21 +19564,21 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.9",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
+      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "chokidar": "^3.2.2",
-        "debug": "^3.2.6",
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.7",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
+        "simple-update-notifier": "^1.0.7",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.3",
-        "update-notifier": "^4.1.0"
+        "undefsafe": "^2.0.5"
       },
       "bin": {
         "nodemon": "bin/nodemon.js"
@@ -20511,14 +19960,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-each-series": {
       "version": "2.2.0",
       "dev": true,
@@ -20606,28 +20047,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/package-json": {
-      "version": "6.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/param-case": {
@@ -21113,17 +20532,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pupa": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-goat": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pure-color": {
       "version": "1.3.0",
       "license": "MIT"
@@ -21210,28 +20618,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -21756,28 +21142,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/registry-auth-token": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/regjsgen": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
@@ -21977,14 +21341,6 @@
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/responselike": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^1.0.0"
-      }
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -22305,25 +21661,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/semver-diff": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/send": {
       "version": "0.18.0",
       "license": "MIT",
@@ -22517,6 +21854,27 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
+      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "~7.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/sisteransi": {
@@ -24292,17 +23650,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/term-size": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "dev": true,
@@ -24425,14 +23772,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-readable-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/to-regex": {
@@ -24980,25 +24319,10 @@
       }
     },
     "node_modules/undefsafe": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.2.0"
-      }
-    },
-    "node_modules/undefsafe/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/undefsafe/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -25147,93 +24471,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/update-notifier": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boxen": "^4.2.0",
-        "chalk": "^3.0.0",
-        "configstore": "^5.0.1",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.1",
-        "is-npm": "^4.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "pupa": "^2.0.1",
-        "semver-diff": "^3.1.1",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
-      }
-    },
-    "node_modules/update-notifier/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/update-notifier/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/update-notifier/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/update-notifier/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/update-notifier/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/update-notifier/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "license": "BSD-2-Clause",
@@ -25245,25 +24482,6 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/url-parse-lax": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/url-parse-lax/node_modules/prepend-http": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -26199,62 +25417,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "4.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "license": "MIT",
@@ -26293,14 +25455,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -29449,10 +28603,6 @@
       "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
       "dev": true
     },
-    "@sindresorhus/is": {
-      "version": "0.14.0",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "dev": true,
@@ -29474,13 +28624,6 @@
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "5.0.1"
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "dev": true,
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
     },
     "@tootallnate/once": {
       "version": "1.1.2"
@@ -29996,39 +29139,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ansi-align": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "ansi-colors": {
@@ -30867,95 +29977,6 @@
     "boolbase": {
       "version": "1.0.0"
     },
-    "boxen": {
-      "version": "4.2.0",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "dev": true
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "dev": true
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "requires": {
@@ -31108,36 +30129,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      }
-    },
-    "cacheable-request": {
-      "version": "6.1.0",
-      "dev": true,
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "normalize-url": {
-          "version": "4.5.1",
-          "dev": true
-        }
       }
     },
     "call-bind": {
@@ -31332,10 +30323,6 @@
       "version": "2.2.0",
       "dev": true
     },
-    "cli-boxes": {
-      "version": "2.2.1",
-      "dev": true
-    },
     "cli-cursor": {
       "version": "3.1.0",
       "dev": true,
@@ -31390,19 +30377,6 @@
           "requires": {
             "ansi-regex": "^6.0.1"
           }
-        }
-      }
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
-      },
-      "dependencies": {
-        "mimic-response": {
-          "version": "1.0.1",
-          "dev": true
         }
       }
     },
@@ -31499,52 +30473,6 @@
     },
     "concat-map": {
       "version": "0.0.1"
-    },
-    "configstore": {
-      "version": "5.0.1",
-      "dev": true,
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "dependencies": {
-        "crypto-random-string": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "make-dir": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        },
-        "unique-string": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "^2.0.0"
-          }
-        },
-        "write-file-atomic": {
-          "version": "3.0.3",
-          "dev": true,
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
-        }
-      }
     },
     "confusing-browser-globals": {
       "version": "1.0.10",
@@ -32069,10 +30997,6 @@
         }
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3"
     },
@@ -32080,10 +31004,6 @@
       "version": "4.2.2",
       "dev": true,
       "peer": true
-    },
-    "defer-to-connect": {
-      "version": "1.1.3",
-      "dev": true
     },
     "define-properties": {
       "version": "1.1.4",
@@ -32232,13 +31152,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "dot-prop": {
-      "version": "5.3.0",
-      "dev": true,
-      "requires": {
-        "is-obj": "^2.0.0"
-      }
-    },
     "dotenv": {
       "version": "16.0.3"
     },
@@ -32251,10 +31164,6 @@
     },
     "duplexer": {
       "version": "0.1.2",
-      "dev": true
-    },
-    "duplexer3": {
-      "version": "0.1.4",
       "dev": true
     },
     "duplexify": {
@@ -32304,10 +31213,6 @@
       "version": "0.7.2",
       "dev": true,
       "peer": true
-    },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -32556,10 +31461,6 @@
     },
     "escalade": {
       "version": "3.1.1"
-    },
-    "escape-goat": {
-      "version": "2.1.1",
-      "dev": true
     },
     "escape-html": {
       "version": "1.0.3"
@@ -33920,19 +32821,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "global-dirs": {
-      "version": "2.1.0",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.7"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "1.3.7",
-          "dev": true
-        }
-      }
-    },
     "globals": {
       "version": "11.12.0"
     },
@@ -33997,36 +32885,6 @@
       "version": "1.0.1",
       "requires": {
         "get-intrinsic": "^1.1.3"
-      }
-    },
-    "got": {
-      "version": "9.6.0",
-      "dev": true,
-      "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "dependencies": {
-        "decompress-response": {
-          "version": "3.3.0",
-          "dev": true,
-          "requires": {
-            "mimic-response": "^1.0.0"
-          }
-        },
-        "mimic-response": {
-          "version": "1.0.1",
-          "dev": true
-        }
       }
     },
     "graceful-fs": {
@@ -34122,10 +32980,6 @@
         }
       }
     },
-    "has-yarn": {
-      "version": "2.1.0",
-      "dev": true
-    },
     "hash-base": {
       "version": "3.1.0",
       "requires": {
@@ -34195,12 +33049,6 @@
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
-    },
-    "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
     },
     "http-errors": {
       "version": "2.0.0",
@@ -34290,10 +33138,6 @@
     "immutable": {
       "version": "4.0.0",
       "devOptional": true
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "dev": true
     },
     "import-local": {
       "version": "3.0.2",
@@ -34529,20 +33373,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-installed-globally": {
-      "version": "0.3.2",
-      "dev": true,
-      "requires": {
-        "global-dirs": "^2.0.1",
-        "is-path-inside": "^3.0.1"
-      },
-      "dependencies": {
-        "is-path-inside": {
-          "version": "3.0.3",
-          "dev": true
-        }
-      }
-    },
     "is-nan": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -34554,10 +33384,6 @@
     },
     "is-negative-zero": {
       "version": "2.0.2",
-      "dev": true
-    },
-    "is-npm": {
-      "version": "4.0.0",
       "dev": true
     },
     "is-number": {
@@ -34578,10 +33404,6 @@
     },
     "is-number-object": {
       "version": "1.0.5",
-      "dev": true
-    },
-    "is-obj": {
-      "version": "2.0.0",
       "dev": true
     },
     "is-plain-obj": {
@@ -34658,10 +33480,6 @@
     },
     "is-windows": {
       "version": "1.0.2",
-      "dev": true
-    },
-    "is-yarn-global": {
-      "version": "0.3.0",
       "dev": true
     },
     "isarray": {
@@ -39045,10 +37863,6 @@
         "bignumber.js": "^9.0.0"
       }
     },
-    "json-buffer": {
-      "version": "3.0.0",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true
@@ -39108,13 +37922,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "keyv": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "kind-of": {
       "version": "6.0.3",
       "dev": true
@@ -39137,13 +37944,6 @@
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
-      }
-    },
-    "latest-version": {
-      "version": "5.1.0",
-      "dev": true,
-      "requires": {
-        "package-json": "^6.3.0"
       }
     },
     "left-pad": {
@@ -39593,10 +38393,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "lru-cache": {
       "version": "6.0.0",
       "requires": {
@@ -39969,19 +38765,21 @@
       }
     },
     "nodemon": {
-      "version": "2.0.9",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
+      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.2.2",
-        "debug": "^3.2.6",
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.7",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
+        "simple-update-notifier": "^1.0.7",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.3",
-        "update-notifier": "^4.1.0"
+        "undefsafe": "^2.0.5"
       },
       "dependencies": {
         "debug": {
@@ -40220,10 +39018,6 @@
         "word-wrap": "~1.2.3"
       }
     },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "p-each-series": {
       "version": "2.2.0",
       "dev": true,
@@ -40268,22 +39062,6 @@
     "p-try": {
       "version": "2.2.0",
       "dev": true
-    },
-    "package-json": {
-      "version": "6.5.0",
-      "dev": true,
-      "requires": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
     },
     "param-case": {
       "version": "3.0.4",
@@ -40595,13 +39373,6 @@
     "punycode": {
       "version": "2.1.1"
     },
-    "pupa": {
-      "version": "2.1.1",
-      "dev": true,
-      "requires": {
-        "escape-goat": "^2.0.0"
-      }
-    },
     "pure-color": {
       "version": "1.3.0"
     },
@@ -40647,22 +39418,6 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "dev": true
-        }
       }
     },
     "react": {
@@ -41021,20 +39776,6 @@
         "unicode-match-property-value-ecmascript": "^2.1.0"
       }
     },
-    "registry-auth-token": {
-      "version": "4.2.1",
-      "dev": true,
-      "requires": {
-        "rc": "^1.2.8"
-      }
-    },
-    "registry-url": {
-      "version": "5.1.0",
-      "dev": true,
-      "requires": {
-        "rc": "^1.2.8"
-      }
-    },
     "regjsgen": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
@@ -41168,13 +39909,6 @@
     "resolve-url": {
       "version": "0.2.1",
       "dev": true
-    },
-    "responselike": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -41388,19 +40122,6 @@
       "version": "5.7.1",
       "dev": true
     },
-    "semver-diff": {
-      "version": "3.1.1",
-      "dev": true,
-      "requires": {
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
-    },
     "send": {
       "version": "0.18.0",
       "requires": {
@@ -41535,6 +40256,23 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-update-notifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
+      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "dev": true,
+      "requires": {
+        "semver": "~7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
       }
     },
     "sisteransi": {
@@ -42682,10 +41420,6 @@
         }
       }
     },
-    "term-size": {
-      "version": "2.2.1",
-      "dev": true
-    },
     "terminal-link": {
       "version": "2.1.1",
       "dev": true,
@@ -42772,10 +41506,6 @@
           }
         }
       }
-    },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "dev": true
     },
     "to-regex": {
       "version": "3.0.2",
@@ -43139,24 +41869,10 @@
       }
     },
     "undefsafe": {
-      "version": "2.0.3",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "dev": true
-        }
-      }
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -43252,64 +41968,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "update-notifier": {
-      "version": "4.1.3",
-      "dev": true,
-      "requires": {
-        "boxen": "^4.2.0",
-        "chalk": "^3.0.0",
-        "configstore": "^5.0.1",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.1",
-        "is-npm": "^4.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "pupa": "^2.0.1",
-        "semver-diff": "^3.1.1",
-        "xdg-basedir": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "uri-js": {
       "version": "4.4.1",
       "requires": {
@@ -43319,19 +41977,6 @@
     "urix": {
       "version": "0.1.0",
       "dev": true
-    },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^2.0.0"
-      },
-      "dependencies": {
-        "prepend-http": {
-          "version": "2.0.0",
-          "dev": true
-        }
-      }
     },
     "use": {
       "version": "3.1.1",
@@ -43937,43 +42582,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "widest-line": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        }
-      }
-    },
     "word-wrap": {
       "version": "1.2.3"
     },
@@ -43992,10 +42600,6 @@
     "ws": {
       "version": "7.5.1",
       "requires": {}
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "lint-staged": "^13.0.3",
     "mock-socket": "^9.1.5",
     "moxios": "^0.4.0",
-    "nodemon": "^2.0.9",
+    "nodemon": "^2.0.20",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "react-error-overlay": "6.0.9",


### PR DESCRIPTION
## High Level Overview of Change

Fixes moderate vulnerability in `got` that is fixed by the dependency being removed. `nodemon` is only used during development.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)