### PR TITLE
fix: remove hover state from legend

### DIFF
--- a/src/containers/shared/css/global.scss
+++ b/src/containers/shared/css/global.scss
@@ -97,7 +97,8 @@ div.react-stockchart div {
   .tx-category-#{$category} {
     color: $color;
 
-    &:hover {
+    // Only have a hover color on anchors
+    @at-root a#{&}:hover {
       color: $hover;
     }
 


### PR DESCRIPTION
## High Level Overview of Change

The homepage legend items changed colors upon hover.  This made them seem like they were meant to be interacted with.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)