### PR TITLE
fix: rename DisallowIncoming flag for NFTs

### DIFF
--- a/src/containers/shared/transactionUtils.ts
+++ b/src/containers/shared/transactionUtils.ts
@@ -74,7 +74,7 @@ export const ACCOUNT_FLAGS: Record<number, string> = {
   15: 'asfDisallowIncomingTrustline',
   14: 'asfDisallowIncomingPayChan',
   13: 'asfDisallowIncomingCheck',
-  12: 'asfDisallowIncomingNFTOffer',
+  12: 'asfDisallowIncomingNFTokenOffer',
   10: 'asfAuthorizedNFTokenMinter',
   9: 'asfDepositAuth',
   8: 'asfDefaultRipple',

--- a/src/rippled/lib/utils.js
+++ b/src/rippled/lib/utils.js
@@ -14,7 +14,7 @@ export const ACCOUNT_FLAGS = {
   0x00400000: 'lsfGlobalFreeze',
   0x00800000: 'lsfDefaultRipple',
   0x01000000: 'lsfDepositAuth',
-  0x04000000: 'lsfDisallowIncomingNFTOffer',
+  0x04000000: 'lsfDisallowIncomingNFTokenOffer',
   0x08000000: 'lsfDisallowIncomingCheck',
   0x10000000: 'lsfDisallowIncomingPayChan',
   0x20000000: 'lsfDisallowIncomingTrustline',


### PR DESCRIPTION
## High Level Overview of Change

`lsfDisallowIncomingNFTOffer` to `lsfDisallowIncomingNFTokenOffer`
`asfDisallowIncomingNFTOffer` to `asfDisallowIncomingNFTokenOffer`

Related to XRPLF/rippled#4442

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)