### PR TITLE
fix: remove circular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,12 +274,6 @@
           "tsx": "never"
         }
       ],
-      "import/no-cycle": [
-        2,
-        {
-          "maxDepth": 5
-        }
-      ],
       "react/jsx-uses-react": "off",
       "react/react-in-jsx-scope": "off",
       "import/prefer-default-export": "off",

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -1,8 +1,9 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
+import axios from 'axios'
 import Log from '../log'
-import { fetchNegativeUNL, fetchQuorum, fetchMetrics } from '../utils'
 import SocketContext from '../SocketContext'
+import { getNegativeUNL, getQuorum } from '../../../rippled'
 import { getLedger, getServerInfo } from '../../../rippled/lib/rippled'
 import { EPOCH_OFFSET } from '../../../rippled/lib/utils'
 import { summarizeLedger } from '../../../rippled/lib/summarizeLedger'
@@ -93,6 +94,29 @@ const formatLedgers = (data) =>
       return { ...ledger, hashes }
     })
     .sort((a, b) => b.ledger_index - a.ledger_index)
+
+export const fetchNegativeUNL = async (rippledSocket) =>
+  getNegativeUNL(rippledSocket)
+    .then((data) => {
+      if (data === undefined) throw new Error('undefined nUNL')
+
+      return data
+    })
+    .catch((e) => Log.error(e))
+
+export const fetchQuorum = async (rippledSocket) =>
+  getQuorum(rippledSocket)
+    .then((data) => {
+      if (data === undefined) throw new Error('undefined quorum')
+      return data
+    })
+    .catch((e) => Log.error(e))
+
+export const fetchMetrics = () =>
+  axios
+    .get('/api/v1/metrics')
+    .then((result) => result.data)
+    .catch((e) => Log.error(e))
 
 class Streams extends Component {
   constructor(props) {

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -1,7 +1,3 @@
-import axios from 'axios'
-import { getQuorum, getNegativeUNL } from '../../rippled'
-import Log from './log'
-
 const THOUSAND = 1000
 const MILLION = THOUSAND * THOUSAND
 const BILLION = MILLION * THOUSAND
@@ -404,29 +400,6 @@ export const durationToHuman = (s, decimal = 2) => {
 
   return `${d.num.toFixed(decimal)} ${d.unit}`
 }
-
-export const fetchNegativeUNL = async (rippledSocket) =>
-  getNegativeUNL(rippledSocket)
-    .then((data) => {
-      if (data === undefined) throw new Error('undefined nUNL')
-
-      return data
-    })
-    .catch((e) => Log.error(e))
-
-export const fetchQuorum = async (rippledSocket) =>
-  getQuorum(rippledSocket)
-    .then((data) => {
-      if (data === undefined) throw new Error('undefined quorum')
-      return data
-    })
-    .catch((e) => Log.error(e))
-
-export const fetchMetrics = () =>
-  axios
-    .get('/api/v1/metrics')
-    .then((result) => result.data)
-    .catch((e) => Log.error(e))
 
 export const removeRoutes = (routes, ...routesToRemove) =>
   routes.filter((route) => !routesToRemove.includes(route.title))


### PR DESCRIPTION
## High Level Overview of Change

Move `fetchNegativeUNL`, `fetchQuorum`, and `fetchMetrics` out of `utils.js` and into `Streams.jsx` (the only place they were used).

This removes 387 circular dependencies and fixes vite's fastRefresh feature.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)