### PR TITLE
fix: show parsed currency code in balance

### DIFF
--- a/src/containers/Accounts/AccountHeader/BalanceSelector.jsx
+++ b/src/containers/Accounts/AccountHeader/BalanceSelector.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import { localizeNumber } from '../../shared/utils'
 import IconDownArrow from '../../shared/images/down_arrow.svg'
 import iconClose from '../../shared/images/close.png'
+import Currency from '../../shared/components/Currency'
 import '../../shared/css/nested-menu.scss'
 import './styles.scss'
 import './balance-selector.scss'
@@ -41,7 +42,9 @@ const BalanceSelector = ({
         }}
         key={currency}
       >
-        <div className="menu-item-currency">{currency}</div>
+        <div className="menu-item-currency">
+          <Currency currency={currency} />
+        </div>
         <div className="menu-item-value">{formattedValue}</div>
       </button>
     )


### PR DESCRIPTION
## High Level Overview of Change

Update account balance selection to use parsed currency code.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before
![Monosnap XRPL Explorer | rsoLo2S1kiGe  2023-03-20 09-55-41](https://user-images.githubusercontent.com/464895/226385486-422e6030-cd7d-47a4-8034-ba33a8025233.png)

## After
![Monosnap XRPL Explorer | rsoLo2S1kiGe  2023-03-20 09-54-57](https://user-images.githubusercontent.com/464895/226385452-0501c31b-9c22-4428-a74d-4487c70d5f7b.png)
