### PR TITLE
refactor: network pages ts, hooks, and no redux

### DIFF
--- a/src/containers/Network/Hexagons.jsx
+++ b/src/containers/Network/Hexagons.jsx
@@ -85,11 +85,12 @@ export const Hexagons = ({ list, data }) => {
   }
 
   const renderHexagon = (d, theHex) => {
-    const fill = `#${d.ledger_hash.substr(0, 6)}`
+    const { cookie, pubkey, ledger_hash: ledgerHash } = d
+    const fill = `#${ledgerHash.substr(0, 6)}`
     const strokeWidth = theHex.radius() / 16
     return (
       <g
-        key={`${d.pubkey}${d.cookie}${d.ledger_hash}`}
+        key={`${pubkey}${cookie}${ledgerHash}`}
         transform={`translate(${d.x},${d.y})`}
         className="hexagon updated"
         onMouseOver={(e) => showTooltip(e, d)}

--- a/src/containers/Network/Hexagons.jsx
+++ b/src/containers/Network/Hexagons.jsx
@@ -1,11 +1,12 @@
-import { Component } from 'react'
+import { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { withTranslation } from 'react-i18next'
+import { useWindowSize } from 'usehooks-ts'
+
 import { hexbin } from 'd3-hexbin'
 import Loader from '../shared/components/Loader'
 import Tooltip from '../shared/components/Tooltip'
 import './css/hexagons.scss'
+import { useLanguage } from '../shared/hooks'
 
 const MAX_WIDTH = 1200
 const getDimensions = (width) => ({
@@ -48,69 +49,55 @@ const prepareHexagons = (data, list, prev = [], height, radius) => {
   })
 }
 
-class Validators extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {}
-  }
+export const Hexagons = ({ list, data }) => {
+  const language = useLanguage()
+  const { width } = useWindowSize()
+  const [tooltip, setToolip] = useState()
+  const [hexagons, setHexagons] = useState([])
+  const { width: gridWidth, height: gridHeight, radius } = getDimensions(width)
+  const bin = hexbin()
+    .extent([
+      [0, 0],
+      [gridWidth, gridHeight],
+    ])
+    .radius(radius)
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const { width, height, radius } = getDimensions(nextProps.width)
-    return {
-      selected: nextProps.selected,
-      list: nextProps.list,
-      hexagons: prepareHexagons(
-        nextProps.data,
-        nextProps.list,
-        prevState.hexagons,
-        height,
-        radius,
-      ),
-      width,
-      height,
-      radius,
-      hex: hexbin()
-        .extent([
-          [0, 0],
-          [width, height],
-        ])
-        .radius(radius),
+  useEffect(() => {
+    if (width > 0) {
+      setHexagons((prevHexagons) =>
+        prepareHexagons(data, list, prevHexagons, gridHeight, radius),
+      )
     }
-  }
+  }, [data, list, width, gridHeight, radius])
 
-  showTooltip = (event, data) => {
-    const { list } = this.state
-    this.setState({
-      tooltip: {
-        ...data,
-        mode: 'validator',
-        v: list[data.pubkey],
-        x: event.nativeEvent.offsetX,
-        y: event.nativeEvent.offsetY,
-      },
+  const showTooltip = (event, tooltipData) => {
+    setToolip({
+      ...tooltipData,
+      mode: 'validator',
+      v: list[tooltipData.pubkey],
+      x: event.nativeEvent.offsetX,
+      y: event.nativeEvent.offsetY,
     })
   }
 
-  hideTooltip = () => {
-    this.setState({ tooltip: null })
+  const hideTooltip = () => {
+    setToolip(null)
   }
 
-  renderHexagon = (d) => {
-    const { selected, hex } = this.state
+  const renderHexagon = (d, theHex) => {
     const fill = `#${d.ledger_hash.substr(0, 6)}`
-    const strokeWidth =
-      selected === d.pubkey ? hex.radius() / 8 : hex.radius() / 16
+    const strokeWidth = theHex.radius() / 16
     return (
       <g
-        key={`${d.pubkey}${d.ledger_hash}`}
+        key={`${d.pubkey}${d.cookie}${d.ledger_hash}`}
         transform={`translate(${d.x},${d.y})`}
-        className={`hexagon updated ${selected === d.pubkey ? 'selected' : ''}`}
-        onMouseOver={(e) => this.showTooltip(e, d)}
+        className="hexagon updated"
+        onMouseOver={(e) => showTooltip(e, d)}
         onFocus={() => {}}
-        onMouseLeave={this.hideTooltip}
+        onMouseLeave={hideTooltip}
       >
         <path
-          d={hex.hexagon(hex.radius() * 0.85)}
+          d={theHex.hexagon(theHex.radius() * 0.85)}
           fill={fill}
           stroke={fill}
           strokeWidth={strokeWidth}
@@ -120,44 +107,30 @@ class Validators extends Component {
     )
   }
 
-  render() {
-    const { height, width, hex, hexagons, tooltip } = this.state
-    const { language } = this.props
-    return (
-      <div className="validators-container">
-        <div className="validators">
-          <svg width={width} height={height}>
-            <g className="mesh">
-              <path
-                fill="none"
-                d={hex.mesh()}
-                strokeWidth={hex.radius() / 8}
-                strokeLinejoin="round"
-              />
-            </g>
-            <g className="hexagons">{hexagons.map(this.renderHexagon)}</g>
-          </svg>
-          {hexagons.length === 0 && <Loader />}
-        </div>
-        <Tooltip language={language} data={tooltip} />
+  return (
+    <div className="validators-container">
+      <div className="validators">
+        <svg width={gridWidth} height={gridHeight}>
+          <g className="mesh">
+            <path
+              fill="none"
+              d={bin.mesh()}
+              strokeWidth={bin.radius() / 8}
+              strokeLinejoin="round"
+            />
+          </g>
+          <g className="hexagons">
+            {hexagons.map((hexagon) => renderHexagon(hexagon, bin))}
+          </g>
+        </svg>
+        {hexagons?.length === 0 && <Loader />}
       </div>
-    )
-  }
+      <Tooltip language={language} data={tooltip} />
+    </div>
+  )
 }
 
-Validators.propTypes = {
-  language: PropTypes.string.isRequired,
+Hexagons.propTypes = {
   list: PropTypes.shape({}).isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // eslint-disable-line
-  width: PropTypes.number.isRequired,
-  selected: PropTypes.string,
 }
-
-Validators.defaultProps = {
-  selected: undefined,
-}
-
-export default connect((state) => ({
-  language: state.app.language,
-  width: state.app.width,
-}))(withTranslation()(Validators))

--- a/src/containers/Network/Nodes.tsx
+++ b/src/containers/Network/Nodes.tsx
@@ -3,56 +3,24 @@ import axios from 'axios'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from 'react-query'
 import NetworkTabs from './NetworkTabs'
-import Map from './Map'
+import { Map } from './Map'
 import NodesTable from './NodesTable'
 import Log from '../shared/log'
 import {
   FETCH_INTERVAL_ERROR_MILLIS,
   FETCH_INTERVAL_NODES_MILLIS,
+  isEarlierVersion,
   localizeNumber,
 } from '../shared/utils'
 import { useLanguage } from '../shared/hooks'
 import { NodeData, NodeResponse } from '../shared/vhsTypes'
 import NetworkContext from '../shared/NetworkContext'
 
-const semverCompare = (a: string | undefined, b: string | undefined) => {
-  if (a == null) {
-    return -1
-  }
-  if (b == null) {
-    return 1
-  }
-  const aWithoutCommitHash = a.split('+')[0]
-  const bWithoutCommitHash = b.split('+')[0]
-  const aVersionSplit = aWithoutCommitHash.split('.')
-  const bVersionSplit = bWithoutCommitHash.split('.')
-
-  for (let i = 0; i < 3; i += 1) {
-    const aNumber = Number(aVersionSplit[i])
-    const bNumber = Number(bVersionSplit[i])
-    if (aNumber > bNumber) {
-      return 1
-    }
-    if (bNumber > aNumber) {
-      return -1
-    }
-    if (!isNaN(aNumber) && isNaN(bNumber)) {
-      return 1
-    }
-    if (isNaN(aNumber) && !isNaN(bNumber)) {
-      return -1
-    }
-  }
-
-  return 0
-}
-
 const ledgerCompare = (a: NodeData, b: NodeData) => {
   const aLedger = a.validated_ledger.ledger_index
   const bLedger = b.validated_ledger.ledger_index
-  return bLedger === aLedger
-    ? semverCompare(b.version, a.version)
-    : bLedger - aLedger
+  const compareVersion = isEarlierVersion(b.version, a.version) ? -1 : 1
+  return bLedger === aLedger ? compareVersion : bLedger - aLedger
 }
 
 export const Nodes = () => {

--- a/src/containers/Network/UpgradeStatus.tsx
+++ b/src/containers/Network/UpgradeStatus.tsx
@@ -5,7 +5,7 @@ import { useQuery } from 'react-query'
 import BarChartVersion from './BarChartVersion'
 import NetworkTabs from './NetworkTabs'
 import Streams from '../shared/components/Streams'
-import Hexagons from './Hexagons'
+import { Hexagons } from './Hexagons'
 import {
   FETCH_INTERVAL_MILLIS,
   FETCH_INTERVAL_ERROR_MILLIS,

--- a/src/containers/Network/Validators.tsx
+++ b/src/containers/Network/Validators.tsx
@@ -12,7 +12,7 @@ import {
   FETCH_INTERVAL_ERROR_MILLIS,
 } from '../shared/utils'
 import { useLanguage } from '../shared/hooks'
-import Hexagons from './Hexagons'
+import { Hexagons } from './Hexagons'
 import { StreamValidator, ValidatorResponse } from '../shared/vhsTypes'
 import NetworkContext from '../shared/NetworkContext'
 

--- a/src/containers/Network/ValidatorsTable.jsx
+++ b/src/containers/Network/ValidatorsTable.jsx
@@ -141,7 +141,7 @@ class ValidatorsTable extends Component {
 }
 
 ValidatorsTable.propTypes = {
-  validators: PropTypes.shape({}),
+  validators: PropTypes.arrayOf(PropTypes.shape({})),
   t: PropTypes.func.isRequired,
   metrics: PropTypes.shape({}).isRequired,
 }

--- a/src/containers/Network/test/nodes.test.js
+++ b/src/containers/Network/test/nodes.test.js
@@ -3,33 +3,29 @@ import moxios from 'moxios'
 import { MemoryRouter as Router, Route } from 'react-router-dom'
 import { QueryClientProvider } from 'react-query'
 import { I18nextProvider } from 'react-i18next'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import { initialState } from '../../App/reducer'
 import i18n from '../../../i18n/testConfig'
 import { Network } from '../index'
 import mockNodes from './mockNodes.json'
 import { testQueryClient } from '../../test/QueryClient'
 import NetworkContext from '../../shared/NetworkContext'
 
-/* eslint-disable react/jsx-props-no-spreading */
-const middlewares = [thunk]
-const mockStore = configureMockStore(middlewares)
-const store = mockStore({ app: initialState })
+jest.mock('usehooks-ts', () => ({
+  useWindowSize: () => ({
+    width: 375,
+    height: 600,
+  }),
+}))
 
 describe('Nodes Page container', () => {
-  const createWrapper = (props = {}) =>
+  const createWrapper = () =>
     mount(
       <QueryClientProvider client={testQueryClient}>
         <I18nextProvider i18n={i18n}>
-          <Provider store={store}>
-            <NetworkContext.Provider value="main">
-              <Router initialEntries={['/network/nodes']}>
-                <Route path="/network/:tab" component={Network} />
-              </Router>
-            </NetworkContext.Provider>
-          </Provider>
+          <NetworkContext.Provider value="main">
+            <Router initialEntries={['/network/nodes']}>
+              <Route path="/network/:tab" component={Network} />
+            </Router>
+          </NetworkContext.Provider>
         </I18nextProvider>
       </QueryClientProvider>,
     )

--- a/src/containers/Network/test/validators.test.js
+++ b/src/containers/Network/test/validators.test.js
@@ -3,11 +3,7 @@ import moxios from 'moxios'
 import WS from 'jest-websocket-mock'
 import { MemoryRouter as Router, Route } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
-import { Provider } from 'react-redux'
 import { QueryClientProvider } from 'react-query'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import { initialState } from '../../App/reducer'
 import i18n from '../../../i18n/testConfig'
 import { Network } from '../index'
 import mockValidators from './mockValidators.json'
@@ -16,27 +12,20 @@ import SocketContext from '../../shared/SocketContext'
 import MockWsClient from '../../test/mockWsClient'
 import { testQueryClient } from '../../test/QueryClient'
 
-/* eslint-disable react/jsx-props-no-spreading */
-const middlewares = [thunk]
-const mockStore = configureMockStore(middlewares)
-const store = mockStore({ app: initialState })
-
 const WS_URL = 'ws://localhost:1234'
 
 describe('Validators Tab container', () => {
   let server
   let client
-  const createWrapper = (props = {}) =>
+  const createWrapper = () =>
     mount(
       <QueryClientProvider client={testQueryClient}>
         <I18nextProvider i18n={i18n}>
-          <Provider store={store}>
-            <SocketContext.Provider value={client}>
-              <Router initialEntries={['/network/validators']}>
-                <Route path="/network/:tab" component={Network} />
-              </Router>
-            </SocketContext.Provider>
-          </Provider>
+          <SocketContext.Provider value={client}>
+            <Router initialEntries={['/network/validators']}>
+              <Route path="/network/:tab" component={Network} />
+            </Router>
+          </SocketContext.Provider>
         </I18nextProvider>
       </QueryClientProvider>,
     )


### PR DESCRIPTION
## High Level Overview of Change

- `<Hexagons>` remove redux and switch to hooks
- `<Map>` remove redux and switch to hooks and ts
- `<Nodes>` use `isEarlierVersion` instead of one off compare

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### TypeScript/Hooks Update

- [x] Updated files to React Hooks
- [x] Updated files to TypeScript

## Future Tasks

Remove countries.json from the javascript bundle and load it separately only on the nodes page.  Will save 39kb gzipped.