### PR TITLE
fix: handle failed xchain transactions

### DIFF
--- a/src/containers/shared/components/Transaction/XChainAddAccountCreateAttestation/test/XChainAddAccountCreateAttestationSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainAddAccountCreateAttestation/test/XChainAddAccountCreateAttestationSimple.test.tsx
@@ -1,6 +1,7 @@
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockXChainAddAccountCreateAttestation from './mock_data/XChainAddAccountCreateAttestation.json'
+import mockXChainAddAccountCreateAttestationFailed from './mock_data/XChainAddAccountCreateAttestationFailed.json'
 import { expectSimpleRowText } from '../../test/expectations'
 
 const createWrapper = createSimpleWrapperFactory(Simple)
@@ -35,6 +36,39 @@ describe('XChainAddAccountCreateAttestationSimple', () => {
       wrapper,
       'destination',
       'rLbKhMNskUBYRShdbbQcFm9YhumEeUJfPK',
+    )
+    expect(wrapper.find(`[data-test="destination"] a`)).toExist()
+  })
+
+  it('renders failed transaction', () => {
+    const wrapper = createWrapper(mockXChainAddAccountCreateAttestationFailed)
+
+    // check XChainBridge parts
+    expectSimpleRowText(
+      wrapper,
+      'locking-chain-door',
+      'rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectSimpleRowText(wrapper, 'send', '\uE90010.00 XRP')
+    expectSimpleRowText(
+      wrapper,
+      'other_chain_source',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expectSimpleRowText(
+      wrapper,
+      'destination',
+      'rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi',
     )
     expect(wrapper.find(`[data-test="destination"] a`)).toExist()
   })

--- a/src/containers/shared/components/Transaction/XChainAddAccountCreateAttestation/test/mock_data/XChainAddAccountCreateAttestationFailed.json
+++ b/src/containers/shared/components/Transaction/XChainAddAccountCreateAttestation/test/mock_data/XChainAddAccountCreateAttestationFailed.json
@@ -1,0 +1,60 @@
+{
+  "tx": {
+    "Account": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+    "Amount": "10000000",
+    "AttestationRewardAccount": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+    "AttestationSignerAccount": "rUvV7YmtbvWyNiapRbZsj4K6Awg9Yxh1Ya",
+    "Destination": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+    "Fee": "20",
+    "LastLedgerSequence": 25,
+    "OtherChainSource": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    "PublicKey": "EDF6CEB8B9AD595A4FC86C9D83EF821B44E47DB7562B384C5692B4D8C901A22430",
+    "Sequence": 13,
+    "Signature": "5DF8ECA9C9D4B398E58DB2E205D2873BB484B4C8FE8835272392F1A5110B9AAF28E58AE58072E41643F83A619081CDE50AAB122B192E21708D232CA673BB8E01",
+    "SignatureReward": "100",
+    "SigningPubKey": "EDA24CE8D77442FBA0AF7FE196073C23E987976FD147085D41B08C4C0BCBF56541",
+    "TransactionType": "XChainAddAccountCreateAttestation",
+    "TxnSignature": "8670FE67798C7D6A4CEAA99F42A42D099536D52C6DBA529961CB02BD36D0605E56A032237F47A4C597CA75224112810A8AB55E770E4BD3834E99A4040BE93709",
+    "WasLockingChainSend": 1,
+    "XChainAccountCreateCount": "c",
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": {
+        "currency": "XRP"
+      },
+      "LockingChainDoor": "rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd",
+      "LockingChainIssue": {
+        "currency": "XRP"
+      }
+    },
+    "date": 1679597991000
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+            "Balance": "30000015",
+            "Flags": 0,
+            "OwnerCount": 0,
+            "Sequence": 14
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "FD8115CC13EF89062204867FAAD75826DD41DBEFEACF4A55DBFE0166294FF182",
+          "PreviousFields": {
+            "Balance": "30000035",
+            "Sequence": 13
+          },
+          "PreviousTxnID": "A5348D1A3C551811EDCDBC9F98586D7FD33834EDD5FC39FFBCA326F6B894D110",
+          "PreviousTxnLgrSeq": 22
+        }
+      }
+    ],
+    "TransactionIndex": 20,
+    "TransactionResult": "tecXCHAIN_ACCOUNT_CREATE_PAST"
+  },
+  "hash": "4D696F9BC6802A2AAADAE7ECBB814BDD99CD0E47FEF3C86249F710C5A8B7273F",
+  "ledger_index": 22,
+  "date": 1679597991000
+}

--- a/src/containers/shared/components/Transaction/XChainAddClaimAttestation/test/XChainAddClaimAttestationSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainAddClaimAttestation/test/XChainAddClaimAttestationSimple.test.tsx
@@ -1,6 +1,7 @@
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockXChainAddClaimAttestation from './mock_data/XChainAddClaimAttestation.json'
+import mockXChainAddClaimAttestationFailed from './mock_data/XChainAddClaimAttestationFailed.json'
 import { expectSimpleRowText } from '../../test/expectations'
 
 const createWrapper = createSimpleWrapperFactory(Simple)
@@ -14,6 +15,40 @@ describe('XChainAddClaimAttestationSimple', () => {
       wrapper,
       'locking-chain-door',
       'r3ZsJYkBao2qiwUCvmjfgEUquKueLAwPxQ',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectSimpleRowText(wrapper, 'send', '\uE90010.00 XRP')
+    expectSimpleRowText(
+      wrapper,
+      'other_chain_source',
+      'raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym',
+    )
+    expectSimpleRowText(
+      wrapper,
+      'destination',
+      'rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi',
+    )
+    expect(wrapper.find(`[data-test="destination"] a`)).toExist()
+    expectSimpleRowText(wrapper, 'xchain-claim-id', '1')
+  })
+
+  it('renders failed transaction', () => {
+    const wrapper = createWrapper(mockXChainAddClaimAttestationFailed)
+
+    // check XChainBridge parts
+    expectSimpleRowText(
+      wrapper,
+      'locking-chain-door',
+      'rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd',
     )
     expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
     expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')

--- a/src/containers/shared/components/Transaction/XChainAddClaimAttestation/test/mock_data/XChainAddClaimAttestationFailed.json
+++ b/src/containers/shared/components/Transaction/XChainAddClaimAttestation/test/mock_data/XChainAddClaimAttestationFailed.json
@@ -1,0 +1,59 @@
+{
+  "tx": {
+    "Account": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+    "Amount": "10000000",
+    "AttestationRewardAccount": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+    "AttestationSignerAccount": "rUvV7YmtbvWyNiapRbZsj4K6Awg9Yxh1Ya",
+    "Destination": "rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi",
+    "Fee": "20",
+    "LastLedgerSequence": 54,
+    "OtherChainSource": "raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym",
+    "PublicKey": "EDF6CEB8B9AD595A4FC86C9D83EF821B44E47DB7562B384C5692B4D8C901A22430",
+    "Sequence": 18,
+    "Signature": "917C77A7354920AA456DCE9144A99F2AC485B03081BB2011553131E1A594C9D145990B03E1BF00413EA3E7F093BA059BB458286174F33C3E58D2881D751B7A05",
+    "SigningPubKey": "EDA24CE8D77442FBA0AF7FE196073C23E987976FD147085D41B08C4C0BCBF56541",
+    "TransactionType": "XChainAddClaimAttestation",
+    "TxnSignature": "72A59AB11BE0271F68E710D2618BB1AA311727C1EB727424FCB83ADD8FA6FC6512644F2D8F0865815283005BBD55E6BD79EE8B77AC50A162DE067F6DC98D8103",
+    "WasLockingChainSend": 1,
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": {
+        "currency": "XRP"
+      },
+      "LockingChainDoor": "rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd",
+      "LockingChainIssue": {
+        "currency": "XRP"
+      }
+    },
+    "XChainClaimID": "3",
+    "date": 1679603821000
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rPy1F9bQ7dNn2T3QAFRM6dFz6ygHa3MDDi",
+            "Balance": "29999915",
+            "Flags": 0,
+            "OwnerCount": 0,
+            "Sequence": 19
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "FD8115CC13EF89062204867FAAD75826DD41DBEFEACF4A55DBFE0166294FF182",
+          "PreviousFields": {
+            "Balance": "29999935",
+            "Sequence": 18
+          },
+          "PreviousTxnID": "23CDA6C9589B7DE88EBC55100FCF28C902F808604FA355767DF92239A559EDED",
+          "PreviousTxnLgrSeq": 22
+        }
+      }
+    ],
+    "TransactionIndex": 4,
+    "TransactionResult": "tecXCHAIN_NO_CLAIM_ID"
+  },
+  "hash": "F8AFD12029ED438AEC29C3621F38C06DEC2A5195DE596D9EFC8B08B3191050F8",
+  "ledger_index": 51,
+  "date": 1679603821000
+}

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/parser.ts
@@ -2,10 +2,6 @@ import { formatAmount } from '../../../../../rippled/lib/txSummary/formatAmount'
 
 export function parser(tx: any, meta: any) {
   const affectedNodes = meta.AffectedNodes
-  const bridgeMeta = affectedNodes.filter(
-    (node: any) =>
-      node.CreatedNode && node.CreatedNode.LedgerEntryType === 'Bridge',
-  )[0]
   return {
     lockingDoor: tx.XChainBridge.LockingChainDoor,
     lockingIssue: tx.XChainBridge.LockingChainIssue,
@@ -13,6 +9,6 @@ export function parser(tx: any, meta: any) {
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
     signatureReward: formatAmount(tx.SignatureReward),
     minAccountCreateAmount: formatAmount(tx.MinAccountCreateAmount),
-    bridgeOwner: bridgeMeta.CreatedNode.NewFields.Account,
+    bridgeOwner: tx.Account,
   }
 }

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/parser.ts
@@ -1,7 +1,6 @@
 import { formatAmount } from '../../../../../rippled/lib/txSummary/formatAmount'
 
-export function parser(tx: any, meta: any) {
-  const affectedNodes = meta.AffectedNodes
+export function parser(tx: any) {
   return {
     lockingDoor: tx.XChainBridge.LockingChainDoor,
     lockingIssue: tx.XChainBridge.LockingChainIssue,

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
@@ -1,5 +1,6 @@
 import { Simple } from '../Simple'
 import mockXChainCreateBridge from './mock_data/XChainCreateBridge.json'
+import mockXChainCreateBridgeFailed from './mock_data/XChainCreateBridgeFailed.json'
 import mockXChainCreateBridgeIOU from './mock_data/XChainCreateBridgeIOU.json'
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 
@@ -63,7 +64,7 @@ describe('XChainCreateBridgeSimple', () => {
   })
 
   it('renders failed tx', () => {
-    const wrapper = createWrapper(mockXChainCreateBridge)
+    const wrapper = createWrapper(mockXChainCreateBridgeFailed)
 
     // check XChainBridge parts
     expectSimpleRowText(

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/test/XChainCreateBridgeSimple.test.tsx
@@ -61,4 +61,27 @@ describe('XChainCreateBridgeSimple', () => {
     expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
     expectSimpleRowText(wrapper, 'min-account-create-amount', '\uE9005.00 XRP')
   })
+
+  it('renders failed tx', () => {
+    const wrapper = createWrapper(mockXChainCreateBridge)
+
+    // check XChainBridge parts
+    expectSimpleRowText(
+      wrapper,
+      'locking-chain-door',
+      'rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9005.00 XRP')
+  })
 })

--- a/src/containers/shared/components/Transaction/XChainCreateBridge/test/mock_data/XChainCreateBridgeFailed.json
+++ b/src/containers/shared/components/Transaction/XChainCreateBridge/test/mock_data/XChainCreateBridgeFailed.json
@@ -1,0 +1,53 @@
+{
+  "tx": {
+    "Account": "rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd",
+    "Fee": "10",
+    "Flags": 0,
+    "LastLedgerSequence": 30,
+    "MinAccountCreateAmount": "5000000",
+    "Sequence": 5,
+    "SignatureReward": "100",
+    "SigningPubKey": "039EEAC2921FED0BE867F5C6BC6206A21A7ECF720982C44A3D503B40CB1374DD6F",
+    "TransactionType": "XChainCreateBridge",
+    "TxnSignature": "3045022100B3127F3D6FE09CEC8DB14A262F1FEA82EB0F24D3882BB875072B82398FECD50602201F802C94B322EA90E51116A5910F8F3EA4BF951AB96EA2256A03E46B087169BD",
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": {
+        "currency": "XRP"
+      },
+      "LockingChainDoor": "rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd",
+      "LockingChainIssue": {
+        "currency": "XRP"
+      }
+    },
+    "date": 1679597660000
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rNFrsx478pH42Vy5w4KN9Hcyh8SDrVmCfd",
+            "Balance": "1070000570",
+            "Flags": 0,
+            "OwnerCount": 2,
+            "Sequence": 6
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "41F98EB375A0FA10B571528507E9BE0BFF807316EB0F8E64656E82DA7F755B6E",
+          "PreviousFields": {
+            "Balance": "1070000580",
+            "Sequence": 5
+          },
+          "PreviousTxnID": "3DB9DF9C3412C4ABFC578E16E37EF3F25C80105F5E8BC5C99A3EF66DD62E11BA",
+          "PreviousTxnLgrSeq": 10
+        }
+      }
+    ],
+    "TransactionIndex": 0,
+    "TransactionResult": "tecDUPLICATE"
+  },
+  "hash": "22BF0818FA3C1E1CE203BD0012FE83454D73B11A8EC06524EEAEA98D8137A6D6",
+  "ledger_index": 11,
+  "date": 1679597660000
+}

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/Simple.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/Simple.tsx
@@ -36,9 +36,11 @@ export const Simple: TransactionSimpleComponent = (
       <SimpleRow label={t('other_chain_source')} data-test="other-chain-source">
         <Account account={otherChainSource} link={false} />
       </SimpleRow>
-      <SimpleRow label={t('xchain_claim_id')} data-test="claim-id">
-        {claimID}
-      </SimpleRow>
+      {claimID && (
+        <SimpleRow label={t('xchain_claim_id')} data-test="claim-id">
+          {claimID}
+        </SimpleRow>
+      )}
     </>
   )
 }

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/parser.ts
@@ -18,7 +18,7 @@ export function parser(tx: any, meta: any) {
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
     signatureReward: formatAmount(tx.SignatureReward),
     otherChainSource: tx.OtherChainSource,
-    bridgeOwner: bridgeMeta.ModifiedNode.FinalFields.Account,
-    claimID: claimIDMeta.CreatedNode.NewFields.XChainClaimID,
+    bridgeOwner: bridgeMeta?.ModifiedNode?.FinalFields?.Account,
+    claimID: claimIDMeta?.CreatedNode?.NewFields?.XChainClaimID,
   }
 }

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/test/XChainCreateClaimIDSimple.test.tsx
@@ -1,6 +1,7 @@
 import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainCreateClaimID from './mock_data/XChainCreateClaimID.json'
+import mockXChainCreateClaimIDFailed from './mock_data/XChainCreateClaimIDFailed.json'
 
 const createWrapper = createSimpleWrapperFactory(Simple)
 
@@ -31,5 +32,33 @@ describe('XChainCreateClaimIDSimple', () => {
       'raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym',
     )
     expectSimpleRowText(wrapper, 'claim-id', '1')
+  })
+
+  it('renders failed transaction', () => {
+    const wrapper = createWrapper(mockXChainCreateClaimIDFailed)
+
+    // check XChainBridge parts
+    expectSimpleRowText(
+      wrapper,
+      'locking-chain-door',
+      'rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.0001 XRP')
+    expectSimpleRowText(
+      wrapper,
+      'other-chain-source',
+      'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+    )
+    expect(wrapper.find(`[data-test="claim-id"]`)).not.toExist()
   })
 })

--- a/src/containers/shared/components/Transaction/XChainCreateClaimID/test/mock_data/XChainCreateClaimIDFailed.json
+++ b/src/containers/shared/components/Transaction/XChainCreateClaimID/test/mock_data/XChainCreateClaimIDFailed.json
@@ -1,0 +1,53 @@
+{
+  "tx": {
+    "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    "Fee": "10",
+    "Flags": 0,
+    "LastLedgerSequence": 35,
+    "OtherChainSource": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+    "Sequence": 28,
+    "SignatureReward": "100",
+    "SigningPubKey": "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+    "TransactionType": "XChainCreateClaimID",
+    "TxnSignature": "3044022055EDB73DDD26044AD04B606541D03E009D290E7DA4BFD58C47999FC83EA8901C022022F63B2959B860E11E01723664534FDC4FA8FE4EFB8C624C600755A9004F82EA",
+    "XChainBridge": {
+      "IssuingChainDoor": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+      "IssuingChainIssue": {
+        "currency": "XRP"
+      },
+      "LockingChainDoor": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+      "LockingChainIssue": {
+        "currency": "XRP"
+      }
+    },
+    "date": 1679603200000
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+            "Balance": "99999987849998220",
+            "Flags": 0,
+            "OwnerCount": 0,
+            "Sequence": 29
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "2B6AC232AA4C4BE41BF49D2459FA4A0347E1B543A4C92FCEE0821C0201E2E9A8",
+          "PreviousFields": {
+            "Balance": "99999987849998230",
+            "Sequence": 28
+          },
+          "PreviousTxnID": "4B1C32DFDB68219E30FD74781C167C4E2BB73847AE46EE7A443129E24D69181A",
+          "PreviousTxnLgrSeq": 14
+        }
+      }
+    ],
+    "TransactionIndex": 0,
+    "TransactionResult": "tecNO_ENTRY"
+  },
+  "hash": "EE77C65171B9C57254605F5F61605D31273CF78209093EEA142A553CD4A19656",
+  "ledger_index": 16,
+  "date": 1679603200000
+}

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/parser.ts
@@ -1,11 +1,6 @@
 import { formatAmount } from '../../../../../rippled/lib/txSummary/formatAmount'
 
-export function parser(tx: any, meta: any) {
-  const affectedNodes = meta.AffectedNodes
-  const bridgeMeta = affectedNodes.filter(
-    (node: any) =>
-      node.ModifiedNode && node.ModifiedNode.LedgerEntryType === 'Bridge',
-  )[0]
+export function parser(tx: any) {
   return {
     lockingDoor: tx.XChainBridge.LockingChainDoor,
     lockingIssue: tx.XChainBridge.LockingChainIssue,
@@ -13,6 +8,6 @@ export function parser(tx: any, meta: any) {
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
     signatureReward: formatAmount(tx.SignatureReward),
     minAccountCreateAmount: formatAmount(tx.MinAccountCreateAmount),
-    bridgeOwner: bridgeMeta.ModifiedNode.FinalFields.Account,
+    bridgeOwner: tx.Account,
   }
 }

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/XChainModifyBridgeSimple.test.tsx
@@ -2,6 +2,7 @@ import { createSimpleWrapperFactory, expectSimpleRowText } from '../../test'
 import { Simple } from '../Simple'
 import mockXChainModifyBridge from './mock_data/XChainModifyBridge.json'
 import mockXChainModifyBridgeMinAccountCreateAmount from './mock_data/XChainModifyBridgeMinAccountCreateAmount.json'
+import mockXChainModifyBridgeNoEntry from './mock_data/XChainModifyBridgeNoEntry.json'
 
 const createWrapper = createSimpleWrapperFactory(Simple)
 
@@ -52,5 +53,27 @@ describe('XChainModifyBridgeSimple', () => {
       'min-account-create-amount',
       '\uE900100.00 XRP',
     )
+  })
+
+  it('renders failed transaction', () => {
+    const wrapper = createWrapper(mockXChainModifyBridgeNoEntry)
+
+    // check XChainBridge parts
+    expectSimpleRowText(
+      wrapper,
+      'locking-chain-door',
+      'r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).toExist()
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectSimpleRowText(wrapper, 'signature-reward', '\uE9000.01 XRP')
   })
 })

--- a/src/containers/shared/components/Transaction/XChainModifyBridge/test/mock_data/XChainModifyBridgeNoEntry.json
+++ b/src/containers/shared/components/Transaction/XChainModifyBridge/test/mock_data/XChainModifyBridgeNoEntry.json
@@ -1,0 +1,52 @@
+{
+  "tx": {
+    "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    "Fee": "10",
+    "Flags": 0,
+    "LastLedgerSequence": 38,
+    "Sequence": 30,
+    "SignatureReward": "100",
+    "SigningPubKey": "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+    "TransactionType": "XChainModifyBridge",
+    "TxnSignature": "304402200F7ECEBC9DF4AD8B651F2DD215299B9F96BE40A6CDBB9A5ABA540CADCD66D88702200C854619DCE57AAE6536C03F6B76D3CF1F382D72DD39BEE13BDC304EFB6ED500",
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": {
+        "currency": "XRP"
+      },
+      "LockingChainDoor": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+      "LockingChainIssue": {
+        "currency": "XRP"
+      }
+    },
+    "date": 1679604320000
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+            "Balance": "99999987849998200",
+            "Flags": 0,
+            "OwnerCount": 0,
+            "Sequence": 31
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "2B6AC232AA4C4BE41BF49D2459FA4A0347E1B543A4C92FCEE0821C0201E2E9A8",
+          "PreviousFields": {
+            "Balance": "99999987849998210",
+            "Sequence": 30
+          },
+          "PreviousTxnID": "30B1D2AE3E64B377B9D0B036F2736CE2A88AD5FD99130DFADCDC534EFAB75D2A",
+          "PreviousTxnLgrSeq": 18
+        }
+      }
+    ],
+    "TransactionIndex": 0,
+    "TransactionResult": "tecNO_ENTRY"
+  },
+  "hash": "72B6CC170F492FF87825A8F288B7F05EBEE321974C2D7A8E39D5034167C6DCA9",
+  "ledger_index": 19,
+  "date": 1679604320000
+}


### PR DESCRIPTION
## High Level Overview of Change

This PR ensures that all of the XLS-38d transaction parsers work for failed-but-validated transactions without crashing. Every transaction that didn't already have one now has a test to confirm that the functionality works as expected.

### Context of Change

Previously, some of the pages would crash upon trying to load a failed-but-validated transaction.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### TypeScript/Hooks Update

N/A

## Before / After

Some pages crashed and now they don't.

## Test Plan

Added tests.
