### PR TITLE
fix: custom network node server crash

### DIFF
--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -4,7 +4,7 @@ const utils = require('./utils')
 const streams = require('./streams')
 
 const RIPPLEDS = []
-process.env.VITE_RIPPLED_HOST.split(',').forEach((d) => {
+process.env.VITE_RIPPLED_HOST?.split(',').forEach((d) => {
   const rippled = d.split(':')
   RIPPLEDS.push(
     `wss://${rippled[0]}:${rippled[1] || process.env.VITE_RIPPLED_WS_PORT}`,


### PR DESCRIPTION
## High Level Overview of Change

The custom network version of the explorer would crash because no rippled host is supplied.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
