### PR TITLE
fix: only use captureStackTrack when available

### DIFF
--- a/src/rippled/lib/utils.js
+++ b/src/rippled/lib/utils.js
@@ -95,7 +95,9 @@ const formatTransaction = (tx) => {
 }
 
 function RippledError(message, code) {
-  Error.captureStackTrace(this, this.constructor)
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor)
+  }
   this.name = this.constructor.name
   this.message = message
   this.code = code


### PR DESCRIPTION
## High Level Overview of Change

This was broken when code was ported to the browser about a year ago.

Fixes #661

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)