### PR TITLE
feat: style XChainBridge parts of xchain transactions to stand out

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,8 @@
         "paystrings",
         "svgr",
         "topojson",
-        "VITE"
+        "VITE",
+        "xchain",
+        "xchainbridge"
     ]
   }

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -443,5 +443,6 @@
   "auth_accounts": "Authorized Accounts",
   "network_cannot_be_crawled": "This network cannot be crawled",
   "check_crawl_existed": "Please contact the operator to make sure they have /crawl accessible or a vl set.",
-  "peer_crawled_context": "For more context, see https://xrpl.org/peer-crawler.html"
+  "peer_crawled_context": "For more context, see https://xrpl.org/peer-crawler.html",
+  "xchainbridge": "XChainBridge"
 }

--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -96,7 +96,7 @@ $subdued-color: $black-40;
     }
 
     .xchainbridge {
-      margin: 16px 0px;
+      margin: 16px 16px 16px 0px;
       background: rgba($black-80, 0.7);
       gap: 15px;
 
@@ -111,7 +111,7 @@ $subdued-color: $black-40;
       }
 
       .row {
-        padding: 16px 44px 12px 16px;
+        padding: 16px 28px 12px 16px;
       }
 
       .row:last-child {

--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -102,7 +102,7 @@ $subdued-color: $black-40;
     }
 
     .group {
-      margin: 16px 16px 16px 0px;
+      margin: 16px 0 16px -16px;
       background: rgba($black-80, 0.7);
       gap: 15px;
 

--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -4,6 +4,8 @@ $subdued-color: $black-40;
 
 .simple-body-tx {
   .rows {
+    padding-top: 0px;
+
     .partial-row {
       display: flex;
       overflow: hidden;
@@ -81,6 +83,10 @@ $subdued-color: $black-40;
           @include regular;
         }
       }
+
+      &:first-child {
+        padding-top: 40px;
+      }
     }
 
     .not-supported {
@@ -112,11 +118,11 @@ $subdued-color: $black-40;
 
       .row {
         padding: 16px 28px 12px 16px;
-      }
 
-      .row:last-child {
-        padding-bottom: 16px;
-        border: none;
+        &:last-child {
+          padding-bottom: 16px;
+          border: none;
+        }
       }
     }
   }

--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -95,12 +95,12 @@ $subdued-color: $black-40;
       }
     }
 
-    .xchainbridge {
+    .group {
       margin: 16px 16px 16px 0px;
       background: rgba($black-80, 0.7);
       gap: 15px;
 
-      .xchainbridge-title {
+      .group-title {
         display: block;
         flex-direction: row;
         padding: 16px 0 0 16px;

--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -95,12 +95,12 @@ $subdued-color: $black-40;
       }
     }
 
-    .attestation {
+    .xchainbridge {
       margin: 16px 0px;
       background: rgba($black-80, 0.7);
       gap: 15px;
 
-      .attestation-title {
+      .xchainbridge-title {
         display: block;
         flex-direction: row;
         padding: 16px 0 0 16px;

--- a/src/containers/shared/components/Transaction/SimpleGroup.tsx
+++ b/src/containers/shared/components/Transaction/SimpleGroup.tsx
@@ -1,0 +1,11 @@
+export type SimpleGroupProps = React.PropsWithChildren<{
+  children: any
+  title?: string
+}>
+
+export const SimpleGroup = ({ children, title }: SimpleGroupProps) => (
+  <div className="group">
+    {title && <div className="group-title">{title}</div>}
+    {children}
+  </div>
+)

--- a/src/containers/shared/components/Transaction/XChainBridge.tsx
+++ b/src/containers/shared/components/Transaction/XChainBridge.tsx
@@ -49,7 +49,8 @@ export const XChainBridge = (props: XChainBridgeProps) => {
   } = props
 
   return (
-    <>
+    <div className="xchainbridge">
+      <div className="xchainbridge-title">{t('xchainbridge')}</div>
       <SimpleRow label={t('locking_chain_door')} data-test="locking-chain-door">
         <Account account={lockingDoor} link={lockingDoor === bridgeOwner} />
       </SimpleRow>
@@ -79,6 +80,6 @@ export const XChainBridge = (props: XChainBridgeProps) => {
           <Amount value={signatureReward} />
         </SimpleRow>
       )}
-    </>
+    </div>
   )
 }

--- a/src/containers/shared/components/Transaction/XChainBridge.tsx
+++ b/src/containers/shared/components/Transaction/XChainBridge.tsx
@@ -3,6 +3,7 @@ import { IssuedCurrency } from '../../types'
 import { Account } from '../Account'
 import { Amount } from '../Amount'
 import Currency from '../Currency'
+import { SimpleGroup } from './SimpleGroup'
 import { SimpleRow } from './SimpleRow'
 
 interface XChainIssueProps {
@@ -49,8 +50,7 @@ export const XChainBridge = (props: XChainBridgeProps) => {
   } = props
 
   return (
-    <div className="xchainbridge">
-      <div className="xchainbridge-title">{t('xchainbridge')}</div>
+    <SimpleGroup title={t('xchainbridge')}>
       <SimpleRow label={t('locking_chain_door')} data-test="locking-chain-door">
         <Account account={lockingDoor} link={lockingDoor === bridgeOwner} />
       </SimpleRow>
@@ -80,6 +80,6 @@ export const XChainBridge = (props: XChainBridgeProps) => {
           <Amount value={signatureReward} />
         </SimpleRow>
       )}
-    </div>
+    </SimpleGroup>
   )
 }


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

The Simple pages for the XChain transactions have a lot of data - having part of it stand out makes it easier to parse the block of information.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

## Before / After

Before: 
![image](https://user-images.githubusercontent.com/8029314/231830404-21bf3c9d-a2ba-4c08-8052-b7964dca5fb7.png)

After:
![image](https://user-images.githubusercontent.com/8029314/231885256-bee05982-915d-4e52-ae50-dd3798e2b37d.png)

## Test Plan

Works locally, only CSS changes.
