### PR TITLE
fix: fix xchainclaim parser crash

### DIFF
--- a/src/containers/shared/components/Transaction/XChainClaim/parser.ts
+++ b/src/containers/shared/components/Transaction/XChainClaim/parser.ts
@@ -17,7 +17,7 @@ export function parser(tx: any, meta: any) {
     lockingIssue: tx.XChainBridge.LockingChainIssue,
     issuingDoor: tx.XChainBridge.IssuingChainDoor,
     issuingIssue: tx.XChainBridge.IssuingChainIssue,
-    bridgeOwner: doorNode.ModifiedNode.FinalFields.Account,
+    bridgeOwner: doorNode?.ModifiedNode?.FinalFields?.Account,
     claimId: tx.XChainClaimID,
     destination: tx.Destination,
     amount: formatAmount(tx.Amount),

--- a/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/XChainClaim/test/XChainClaimSimple.test.tsx
@@ -32,4 +32,32 @@ describe('XChainClaimSimple', () => {
     )
     expectSimpleRowText(wrapper, 'claim-id', '5')
   })
+
+  it('renders failed tx', () => {
+    const wrapper = createWrapper(mockXChainClaim)
+
+    // check XChainBridge parts
+    expectSimpleRowText(
+      wrapper,
+      'locking-chain-door',
+      'rMAXACCrp3Y8PpswXcg3bKggHX76V3F8M4',
+    )
+    expect(wrapper.find(`[data-test="locking-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'locking-chain-issue', 'XRP')
+    expectSimpleRowText(
+      wrapper,
+      'issuing-chain-door',
+      'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    )
+    expect(wrapper.find(`[data-test="issuing-chain-door"] a`)).not.toExist()
+    expectSimpleRowText(wrapper, 'issuing-chain-issue', 'XRP')
+
+    expectSimpleRowText(wrapper, 'amount', '\uE9000.01 XRP')
+    expectSimpleRowText(
+      wrapper,
+      'destination',
+      'rpwoKyUQn5uGDKeF6LhxK8HWS25ZMhFpaB',
+    )
+    expectSimpleRowText(wrapper, 'claim-id', '492')
+  })
 })

--- a/src/containers/shared/components/Transaction/XChainClaim/test/mock_data/XChainClaimNoQuorum.json
+++ b/src/containers/shared/components/Transaction/XChainClaim/test/mock_data/XChainClaimNoQuorum.json
@@ -1,0 +1,53 @@
+{
+  "tx": {
+    "Account": "rpwoKyUQn5uGDKeF6LhxK8HWS25ZMhFpaB",
+    "Amount": "10000",
+    "Destination": "rpwoKyUQn5uGDKeF6LhxK8HWS25ZMhFpaB",
+    "Fee": "20",
+    "Flags": 2147483648,
+    "Sequence": 454709,
+    "SigningPubKey": "0203811EDCB57C1B6F34640DD494F04F347A45C58709ED8FFC176D5C9B6E9DF5E5",
+    "TransactionType": "XChainClaim",
+    "TxnSignature": "304402205FEC71E444ABE6F613ABA7052AD40106D3B694A2316AC2B020BB78C7110BE4E40220325189A44F5F7EDA7E622FEDAD1207973B7FB6E9CDE03E7EEEE6A971CDC858A1",
+    "XChainBridge": {
+      "IssuingChainDoor": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "IssuingChainIssue": {
+        "currency": "XRP"
+      },
+      "LockingChainDoor": "rMAXACCrp3Y8PpswXcg3bKggHX76V3F8M4",
+      "LockingChainIssue": {
+        "currency": "XRP"
+      }
+    },
+    "XChainClaimID": "492",
+    "date": 1681400481000
+  },
+  "meta": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rpwoKyUQn5uGDKeF6LhxK8HWS25ZMhFpaB",
+            "Balance": "39999960",
+            "Flags": 0,
+            "OwnerCount": 1,
+            "Sequence": 454710
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "5334EC2845E583BBEC4C75EF27498BD47D643BD572DE91DF00A0AF532FEDA6B1",
+          "PreviousFields": {
+            "Balance": "39999980",
+            "Sequence": 454709
+          },
+          "PreviousTxnID": "850F18C0BC4B7BFDF1F48902E9D9D4D6AFA4B0D88AA0186CAB9A2D95F6B4862F",
+          "PreviousTxnLgrSeq": 454709
+        }
+      }
+    ],
+    "TransactionIndex": 1,
+    "TransactionResult": "tecXCHAIN_CLAIM_NO_QUORUM"
+  },
+  "hash": "14DB8385E209E38D83F209EF6C90571B958DC711DB7741A3329F21130AB1A394",
+  "ledger_index": 454720,
+  "date": 1681400481000
+}


### PR DESCRIPTION
## High Level Overview of Change

The XChainClaim tx parser crashes on failed transactions, due to metadata parsing. This PR fixes that parsing.

### Context of Change

Noticed while perusing the explorer

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test for the transaction that caused the crash.
