### PR TITLE
fix: decode selected currency in account header

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -49,6 +49,7 @@
   "accounts.other_balances_short": "Other Bal.",
   "amount": "Amount",
   "currency_code": "Currency Code",
+  "currency_balance": "<0>{{currency}}</0> Balance",
   "load_more_action": "Load more...",
   "account_transactions": "Account Transactions",
   "transaction_type": "Transaction Type",

--- a/src/containers/Accounts/AccountHeader/index.tsx
+++ b/src/containers/Accounts/AccountHeader/index.tsx
@@ -11,6 +11,7 @@ import { localizeNumber } from '../../shared/utils'
 import SocketContext from '../../shared/SocketContext'
 import InfoIcon from '../../shared/images/info.svg'
 import { useLanguage } from '../../shared/hooks'
+import Currency from '../../shared/components/Currency'
 
 const CURRENCY_OPTIONS = {
   style: 'currency',
@@ -318,7 +319,9 @@ const AccountHeader = (props: AccountHeaderProps) => {
               </div>
             ) : (
               <>
-                <div className="title">{`${currencySelected} Balance`}</div>
+                <div className="title">
+                  <Currency currency={currencySelected} /> Balance
+                </div>
                 <div className="value">{balance}</div>
               </>
             )}

--- a/src/containers/Accounts/AccountHeader/index.tsx
+++ b/src/containers/Accounts/AccountHeader/index.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { loadAccountState } from './actions'
@@ -320,7 +320,9 @@ const AccountHeader = (props: AccountHeaderProps) => {
             ) : (
               <>
                 <div className="title">
-                  <Currency currency={currencySelected} /> Balance
+                  <Trans i18nKey="currency_balance">
+                    <Currency currency={currencySelected} />
+                  </Trans>
                 </div>
                 <div className="value">{balance}</div>
               </>


### PR DESCRIPTION

## High Level Overview of Change

Related to #631 which fixed inside selector but not selected value

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Before
![Balance - Before](https://user-images.githubusercontent.com/464895/231845363-86c315b2-b17b-469c-ad40-fc87a982025a.png)

## After
![Balance - AFter](https://user-images.githubusercontent.com/464895/231845375-28afe150-77c7-4c4e-bda3-0e96bfd5935b.png)

