### PR TITLE
fix: show whole account in signer list

### DIFF
--- a/src/containers/Accounts/AccountHeader/styles.scss
+++ b/src/containers/Accounts/AccountHeader/styles.scss
@@ -240,7 +240,7 @@
 
           .account {
             overflow: hidden;
-            width: 285px;
+            width: 300px;
             padding-right: 10px;
             color: $white;
             text-overflow: ellipsis;


### PR DESCRIPTION
## High Level Overview of Change

Only a couple of the characters were hidden in some accounts in signer lists. This PR expands the box just a bit to fix that.

### Context of Change

Noticed while browsing

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before:
![image](https://user-images.githubusercontent.com/8029314/234135083-bbfda552-5aec-43dc-8e36-5ff700d8b75f.png)

After:
![image](https://user-images.githubusercontent.com/8029314/234135129-424f93b0-6c4a-45a3-bab4-9731c05613e0.png)

## Test Plan

Works locally.
