### PR TITLE
refactor: switched more files to hooks and ts

### DIFF
--- a/src/containers/Token/index.tsx
+++ b/src/containers/Token/index.tsx
@@ -70,7 +70,7 @@ const Token: FC<{ error: string }> = ({ error }) => {
     <div className="token-page">
       {accountId && <TokenHeader accountId={accountId} currency={currency} />}
       {accountId && IS_MAINNET && (
-        <DEXPairs accountId={accountId} currency={currency} t={t} />
+        <DEXPairs accountId={accountId} currency={currency} />
       )}
       {accountId && (
         <div className="section">

--- a/src/containers/Token/index.tsx
+++ b/src/containers/Token/index.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react'
-import PropTypes from 'prop-types'
+import { FC, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { connect } from 'react-redux'
 
@@ -16,30 +15,34 @@ import {
   NOT_FOUND,
   BAD_REQUEST,
 } from '../shared/utils'
+import { ErrorMessages } from '../shared/Interfaces'
 
 const IS_MAINNET = process.env.VITE_ENVIRONMENT === 'mainnet'
 
-const ERROR_MESSAGES = {}
-ERROR_MESSAGES[NOT_FOUND] = {
-  title: 'account_not_found',
-  hints: ['check_account_id'],
-}
-ERROR_MESSAGES[BAD_REQUEST] = {
-  title: 'invalid_xrpl_address',
-  hints: ['check_account_id'],
-}
-ERROR_MESSAGES.default = {
-  title: 'generic_error',
-  hints: ['not_your_fault'],
+const ERROR_MESSAGES: ErrorMessages = {
+  default: {
+    title: 'generic_error',
+    hints: ['not_your_fault'],
+  },
+  [NOT_FOUND]: {
+    title: 'account_not_found',
+    hints: ['check_account_id'],
+  },
+  [BAD_REQUEST]: {
+    title: 'invalid_xrpl_address',
+    hints: ['check_account_id'],
+  },
 }
 
 const getErrorMessage = (error) =>
   ERROR_MESSAGES[error] || ERROR_MESSAGES.default
 
-const Token = ({ error }) => {
-  const { currency, id: accountId } = useParams()
+const Token: FC<{ error: string }> = ({ error }) => {
+  const { currency, id: accountId } = useParams<{
+    currency: string
+    id: string
+  }>()
   const { t } = useTranslation()
-  const showError = error
 
   useEffect(() => {
     document.title = `${t('xrpl_explorer')} | ${accountId.substr(0, 12)}...`
@@ -59,13 +62,11 @@ const Token = ({ error }) => {
     )
   }
 
-  return showError ? (
-    renderError(error)
+  return error ? (
+    renderError()
   ) : (
     <div className="token-page">
-      {accountId && (
-        <TokenHeader accountId={accountId} currency={currency} t={t} />
-      )}
+      {accountId && <TokenHeader accountId={accountId} currency={currency} />}
       {accountId && IS_MAINNET && (
         <DEXPairs accountId={accountId} currency={currency} t={t} />
       )}
@@ -84,20 +85,6 @@ const Token = ({ error }) => {
   )
 }
 
-Token.propTypes = {
-  error: PropTypes.number,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      currency: PropTypes.string,
-    }),
-  }).isRequired,
-}
-
-Token.defaultProps = {
-  error: null,
-}
-
-export default connect((state) => ({
+export default connect((state: any) => ({
   error: state.accountHeader.status,
 }))(Token)

--- a/src/containers/Token/index.tsx
+++ b/src/containers/Token/index.tsx
@@ -62,9 +62,11 @@ const Token: FC<{ error: string }> = ({ error }) => {
     )
   }
 
-  return error ? (
-    renderError()
-  ) : (
+  if (error) {
+    return renderError()
+  }
+
+  return (
     <div className="token-page">
       {accountId && <TokenHeader accountId={accountId} currency={currency} />}
       {accountId && IS_MAINNET && (

--- a/src/containers/Transactions/Description/index.tsx
+++ b/src/containers/Transactions/Description/index.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from 'react-i18next'
-import PropTypes from 'prop-types'
+import { FC } from 'react'
 import Sequence from '../../shared/components/Sequence'
 import { transactionTypes } from '../../shared/components/Transaction'
 
-const TransactionDescription = ({ data }) => {
+export const TransactionDescription: FC<{ data: any }> = ({ data }) => {
   const { t } = useTranslation()
 
   if (!data || !data.tx) {
@@ -32,16 +32,3 @@ const TransactionDescription = ({ data }) => {
     </div>
   )
 }
-
-TransactionDescription.propTypes = {
-  data: PropTypes.objectOf(
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-      PropTypes.number,
-      PropTypes.array,
-    ]),
-  ).isRequired,
-}
-
-export default TransactionDescription

--- a/src/containers/Transactions/DetailTab.jsx
+++ b/src/containers/Transactions/DetailTab.jsx
@@ -1,9 +1,8 @@
-import { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import TransactionMeta from './Meta'
-import TransactionDescription from './Description'
+import { TransactionMeta } from './Meta'
+import { TransactionDescription } from './Description'
 import { Account } from '../shared/components/Account'
 import { localizeDate, localizeNumber } from '../shared/utils'
 import {
@@ -15,10 +14,13 @@ import {
   buildMemos,
 } from '../shared/transactionUtils'
 import './detailTab.scss'
+import { useLanguage } from '../shared/hooks'
 
-class DetailTab extends Component {
-  renderStatus() {
-    const { t, language, data } = this.props
+const DetailTab = ({ data }) => {
+  const { t } = useTranslation()
+  const language = useLanguage()
+
+  const renderStatus = () => {
     const { TransactionResult } = data.meta
     const time = localizeDate(new Date(data.date), language, DATE_OPTIONS)
     let line1
@@ -47,8 +49,7 @@ class DetailTab extends Component {
     )
   }
 
-  renderMemos() {
-    const { t, data } = this.props
+  const renderMemos = () => {
     const memos = buildMemos(data)
     return memos.length ? (
       <div className="detail-section">
@@ -63,8 +64,7 @@ class DetailTab extends Component {
     ) : null
   }
 
-  renderFee() {
-    const { t, data, language } = this.props
+  const renderFee = () => {
     const numberOptions = { ...CURRENCY_OPTIONS, currency: 'XRP' }
     const totalCost = data.tx.Fee
       ? localizeNumber(
@@ -89,8 +89,7 @@ class DetailTab extends Component {
     )
   }
 
-  renderFlags() {
-    const { t, data } = this.props
+  const renderFlags = () => {
     const flags = buildFlags(data)
     return flags.length ? (
       <div className="detail-section">
@@ -104,9 +103,8 @@ class DetailTab extends Component {
     ) : null
   }
 
-  renderSigners() {
-    const { t, data } = this.props
-    return data.tx.Signers ? (
+  const renderSigners = () =>
+    data.tx.Signers ? (
       <div className="detail-section">
         <div className="title">{t('signers')}</div>
         <ul className="signers">
@@ -118,27 +116,21 @@ class DetailTab extends Component {
         </ul>
       </div>
     ) : null
-  }
 
-  render() {
-    const { t, language, data, instructions } = this.props
-    return (
-      <div className="detail-body">
-        {this.renderStatus()}
-        <TransactionDescription data={data} instructions={instructions} />
-        {this.renderSigners()}
-        {this.renderFlags()}
-        {this.renderFee()}
-        {this.renderMemos()}
-        <TransactionMeta t={t} language={language} data={data} />
-      </div>
-    )
-  }
+  return (
+    <div className="detail-body">
+      {renderStatus()}
+      <TransactionDescription data={data} />
+      {renderSigners()}
+      {renderFlags()}
+      {renderFee()}
+      {renderMemos()}
+      <TransactionMeta data={data} />
+    </div>
+  )
 }
 
 DetailTab.propTypes = {
-  t: PropTypes.func.isRequired,
-  language: PropTypes.string.isRequired,
   data: PropTypes.objectOf(
     PropTypes.oneOfType([
       PropTypes.string,
@@ -147,7 +139,6 @@ DetailTab.propTypes = {
       PropTypes.array,
     ]),
   ).isRequired,
-  instructions: PropTypes.shape({}).isRequired,
 }
 
 export default DetailTab

--- a/src/containers/Transactions/Meta/index.jsx
+++ b/src/containers/Transactions/Meta/index.jsx
@@ -1,11 +1,12 @@
-import { Component } from 'react'
 import PropTypes from 'prop-types'
+import { useTranslation } from 'react-i18next'
 import renderAccountRoot from './AccountRoot'
 import renderDirectoryNode from './DirectoryNode'
 import renderOffer from './Offer'
 import renderRippleState from './RippleState'
 import renderPayChannel from './PayChannel'
 import { groupAffectedNodes } from '../../shared/transactionUtils'
+import { useLanguage } from '../../shared/hooks'
 
 const renderDefault = (t, action, node, index) => (
   <li key={`${node.LedgerEntryType}_${index}`} className="meta-line">
@@ -13,8 +14,11 @@ const renderDefault = (t, action, node, index) => (
   </li>
 )
 
-class TransactionMeta extends Component {
-  static renderNodesMeta(t, language, action, list, tx) {
+export const TransactionMeta = ({ data }) => {
+  const language = useLanguage()
+  const { t } = useTranslation()
+
+  const renderNodesMeta = (action, list, tx) => {
     const meta = list.map((node, index) => {
       switch (node.LedgerEntryType) {
         case 'AccountRoot':
@@ -42,47 +46,24 @@ class TransactionMeta extends Component {
     )
   }
 
-  render() {
-    const { t, language, data } = this.props
-    const affectedNodes = groupAffectedNodes(data)
+  const affectedNodes = groupAffectedNodes(data)
 
-    return (
-      <div className="detail-section">
-        <div className="title">{t('meta')}</div>
-        <div>
-          {t('number_of_affected_node', {
-            count: data.meta.AffectedNodes.length,
-          })}
-        </div>
-        {TransactionMeta.renderNodesMeta(
-          t,
-          language,
-          'created',
-          affectedNodes.created,
-          data.tx,
-        )}
-        {TransactionMeta.renderNodesMeta(
-          t,
-          language,
-          'modified',
-          affectedNodes.modified,
-          data.tx,
-        )}
-        {TransactionMeta.renderNodesMeta(
-          t,
-          language,
-          'deleted',
-          affectedNodes.deleted,
-          data.tx,
-        )}
+  return (
+    <div className="detail-section">
+      <div className="title">{t('meta')}</div>
+      <div>
+        {t('number_of_affected_node', {
+          count: data.meta.AffectedNodes.length,
+        })}
       </div>
-    )
-  }
+      {renderNodesMeta('created', affectedNodes.created, data.tx)}
+      {renderNodesMeta('modified', affectedNodes.modified, data.tx)}
+      {renderNodesMeta('deleted', affectedNodes.deleted, data.tx)}
+    </div>
+  )
 }
 
 TransactionMeta.propTypes = {
-  t: PropTypes.func.isRequired,
-  language: PropTypes.string.isRequired,
   data: PropTypes.objectOf(
     PropTypes.oneOfType([
       PropTypes.string,
@@ -92,5 +73,3 @@ TransactionMeta.propTypes = {
     ]),
   ).isRequired,
 }
-
-export default TransactionMeta

--- a/src/containers/Transactions/Simple/index.tsx
+++ b/src/containers/Transactions/Simple/index.tsx
@@ -1,17 +1,15 @@
-import PropTypes from 'prop-types'
+import { FC } from 'react'
 import { transactionTypes } from '../../shared/components/Transaction'
 import { DefaultSimple } from '../../shared/components/Transaction/DefaultSimple'
 
-export const Simple = ({ data, type }) => {
+export const Simple: FC<{
+  data: any
+  type: string
+}> = ({ data, type }) => {
   // Locate the component for the left side of the simple tab that is unique per TransactionType.
   const SimpleComponent = transactionTypes[type]?.Simple
   if (SimpleComponent) {
     return <SimpleComponent data={data} />
   }
   return <DefaultSimple data={data} />
-}
-
-Simple.propTypes = {
-  data: PropTypes.shape({}).isRequired,
-  type: PropTypes.string.isRequired,
 }

--- a/src/containers/Transactions/SimpleTab.jsx
+++ b/src/containers/Transactions/SimpleTab.jsx
@@ -1,15 +1,17 @@
-import { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { localizeDate, localizeNumber, BREAKPOINTS } from '../shared/utils'
 import { Account } from '../shared/components/Account'
 import Sequence from '../shared/components/Sequence'
 import { Simple } from './Simple'
+
+import { useLanguage } from '../shared/hooks'
+import { CURRENCY_OPTIONS, XRP_BASE } from '../shared/transactionUtils'
+import { SimpleRow } from '../shared/components/Transaction/SimpleRow'
 import '../shared/css/simpleTab.scss'
 import './simpleTab.scss'
-import { SimpleRow } from '../shared/components/Transaction/SimpleRow'
 
-const XRP_BASE = 1000000
 const TIME_ZONE = 'UTC'
 const DATE_OPTIONS = {
   hour: 'numeric',
@@ -21,84 +23,81 @@ const DATE_OPTIONS = {
   hour12: true,
   timeZone: TIME_ZONE,
 }
-const CURRENCY_OPTIONS = {
-  style: 'currency',
-  currency: '',
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 8,
-}
-class SimpleTab extends Component {
-  renderRowIndex(time, ledgerIndex, fee, account, sequence, ticketSequence) {
-    const { t } = this.props
-    return (
-      <>
-        <SimpleRow
-          label={t('formatted_date', { timeZone: TIME_ZONE })}
-          data-test="tx-date"
-        >
-          {time}
-        </SimpleRow>
-        <SimpleRow label={t('ledger_index')} data-test="ledger-index">
-          <Link to={`/ledgers/${ledgerIndex}`}>{ledgerIndex}</Link>
-        </SimpleRow>
-        <SimpleRow label={t('account')} data-test="account">
-          <Account account={account} />
-        </SimpleRow>
-        <SimpleRow label={t('sequence_number')} data-test="sequence">
-          <Sequence
-            sequence={sequence}
-            ticketSequence={ticketSequence}
-            account={account}
-          />
-        </SimpleRow>
-        <SimpleRow label={t('transaction_cost')} data-test="tx-cost">
-          {fee}
-        </SimpleRow>
-      </>
-    )
-  }
 
-  render() {
-    const { language, data, width } = this.props
-    const { raw } = data
-    const numberOptions = { ...CURRENCY_OPTIONS, currency: 'XRP' }
-    const time = localizeDate(new Date(raw.date), language, DATE_OPTIONS)
-    const ledgerIndex = raw.ledger_index
-    const fee = raw.tx.Fee
-      ? localizeNumber(
-          Number.parseFloat(raw.tx.Fee) / XRP_BASE,
-          language,
-          numberOptions,
-        )
-      : 0
+const SimpleTab = ({ data, width }) => {
+  const { t } = useTranslation()
+  const language = useLanguage()
 
-    const rowIndex = this.renderRowIndex(
-      time,
-      ledgerIndex,
-      fee,
-      raw.tx.Account,
-      raw.tx.Sequence,
-      raw.tx.TicketSequence,
-    )
+  const renderRowIndex = (
+    time,
+    ledgerIndex,
+    fee,
+    account,
+    sequence,
+    ticketSequence,
+  ) => (
+    <>
+      <SimpleRow
+        label={t('formatted_date', { timeZone: TIME_ZONE })}
+        data-test="tx-date"
+      >
+        {time}
+      </SimpleRow>
+      <SimpleRow label={t('ledger_index')} data-test="ledger-index">
+        <Link to={`/ledgers/${ledgerIndex}`}>{ledgerIndex}</Link>
+      </SimpleRow>
+      <SimpleRow label={t('account')} data-test="account">
+        <Account account={account} />
+      </SimpleRow>
+      <SimpleRow label={t('sequence_number')} data-test="sequence">
+        <Sequence
+          sequence={sequence}
+          ticketSequence={ticketSequence}
+          account={account}
+        />
+      </SimpleRow>
+      <SimpleRow label={t('transaction_cost')} data-test="tx-cost">
+        {fee}
+      </SimpleRow>
+    </>
+  )
 
-    return (
-      <div className="simple-body simple-body-tx">
-        <div className="rows">
-          <Simple type={raw.tx.TransactionType} data={data.summary} />
-          {width < BREAKPOINTS.landscape && rowIndex}
-        </div>
-        {width >= BREAKPOINTS.landscape && (
-          <div className="index">{rowIndex}</div>
-        )}
-        <div className="clear" />
+  const { raw } = data
+  const numberOptions = { ...CURRENCY_OPTIONS, currency: 'XRP' }
+  const time = localizeDate(new Date(raw.date), language, DATE_OPTIONS)
+  const ledgerIndex = raw.ledger_index
+  const fee = raw.tx.Fee
+    ? localizeNumber(
+        Number.parseFloat(raw.tx.Fee) / XRP_BASE,
+        language,
+        numberOptions,
+      )
+    : 0
+
+  const rowIndex = renderRowIndex(
+    time,
+    ledgerIndex,
+    fee,
+    raw.tx.Account,
+    raw.tx.Sequence,
+    raw.tx.TicketSequence,
+  )
+
+  return (
+    <div className="simple-body simple-body-tx">
+      <div className="rows">
+        <Simple type={raw.tx.TransactionType} data={data.summary} />
+        {width < BREAKPOINTS.landscape && rowIndex}
       </div>
-    )
-  }
+      {width >= BREAKPOINTS.landscape && (
+        <div className="index">{rowIndex}</div>
+      )}
+      <div className="clear" />
+    </div>
+  )
 }
 
 SimpleTab.propTypes = {
-  t: PropTypes.func.isRequired,
-  language: PropTypes.string.isRequired,
   width: PropTypes.number.isRequired,
   data: PropTypes.objectOf(
     PropTypes.oneOfType([
@@ -110,4 +109,4 @@ SimpleTab.propTypes = {
   ).isRequired,
 }
 
-export default SimpleTab
+export { SimpleTab }

--- a/src/containers/Transactions/index.tsx
+++ b/src/containers/Transactions/index.tsx
@@ -14,13 +14,12 @@ import {
   BAD_REQUEST,
   HASH_REGEX,
 } from '../shared/utils'
-import SimpleTab from './SimpleTab'
+import { SimpleTab } from './SimpleTab'
 import DetailTab from './DetailTab'
 import './transaction.scss'
 import SocketContext from '../shared/SocketContext'
 import { TxStatus } from '../shared/components/TxStatus'
 import { getTransaction } from '../../rippled'
-import { useLanguage } from '../shared/hooks'
 
 const ERROR_MESSAGES: Record<string, { title: string; hints: string[] }> = {}
 ERROR_MESSAGES[NOT_FOUND] = {
@@ -72,7 +71,6 @@ export const Transaction = () => {
     },
   )
   const { width } = useWindowSize()
-  const language = useLanguage()
 
   const short = identifier.substr(0, 8)
   document.title = `${t('xrpl_explorer')} | ${t(
@@ -114,14 +112,7 @@ export const Transaction = () => {
 
     switch (tab) {
       case 'detailed':
-        body = (
-          <DetailTab
-            t={t}
-            language={language}
-            data={data.raw}
-            instructions={data.summary?.instructions}
-          />
-        )
+        body = <DetailTab data={data.raw} />
         break
       case 'raw':
         body = (
@@ -137,7 +128,7 @@ export const Transaction = () => {
         )
         break
       default:
-        body = <SimpleTab t={t} language={language} data={data} width={width} />
+        body = <SimpleTab data={data} width={width} />
         break
     }
     return (

--- a/src/containers/Transactions/test/Description.test.tsx
+++ b/src/containers/Transactions/test/Description.test.tsx
@@ -2,19 +2,14 @@ import { mount } from 'enzyme'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../../i18n/testConfig'
-import Description from '../Description'
+import { TransactionDescription } from '../Description'
 
 describe('Description container', () => {
-  const createWrapper = (data = {}, instructions = {}) =>
+  const createWrapper = (data = {}) =>
     mount(
       <Router>
         <I18nextProvider i18n={i18n}>
-          <Description
-            t={(s) => s}
-            language="en-US"
-            data={data}
-            instructions={instructions}
-          />
+          <TransactionDescription data={data} />
         </I18nextProvider>
       </Router>,
     )

--- a/src/containers/Transactions/test/DetailTab.test.tsx
+++ b/src/containers/Transactions/test/DetailTab.test.tsx
@@ -7,11 +7,11 @@ import DetailTab from '../DetailTab'
 import i18n from '../../../i18n/testConfigEnglish'
 
 describe('DetailTab container', () => {
-  const createWrapper = (transaction = Transaction) =>
+  const createWrapper = (transaction: any = Transaction) =>
     mount(
       <Router>
         <I18nextProvider i18n={i18n}>
-          <DetailTab t={i18n.t} language="en-US" data={transaction} />
+          <DetailTab data={transaction} />
         </I18nextProvider>
       </Router>,
     )

--- a/src/containers/Transactions/test/Meta.test.tsx
+++ b/src/containers/Transactions/test/Meta.test.tsx
@@ -6,14 +6,14 @@ import Transaction from './mock_data/Transaction.json'
 import OfferCancel from '../../shared/components/Transaction/OfferCancel/test/mock_data/OfferCancel.json'
 import OfferCreateWithMissingPreviousFields from '../../shared/components/Transaction/OfferCreate/test/mock_data/OfferCreateWithMissingPreviousFields.json'
 import PaymentChannelClaim from '../../shared/components/Transaction/PaymentChannelClaim/test/mock_data/PaymentChannelClaim.json'
-import Meta from '../Meta'
+import { TransactionMeta } from '../Meta'
 
 describe('TransactionMeta container', () => {
-  const createWrapper = (data = Transaction) =>
+  const createWrapper = (data: any = Transaction) =>
     mount(
       <Router>
         <I18nextProvider i18n={i18n}>
-          <Meta t={(s) => s} language="en-US" data={data} />
+          <TransactionMeta data={data} />
         </I18nextProvider>
       </Router>,
     )

--- a/src/containers/Transactions/test/SimpleTab.test.js
+++ b/src/containers/Transactions/test/SimpleTab.test.js
@@ -1,10 +1,10 @@
 import { mount } from 'enzyme'
 import { I18nextProvider } from 'react-i18next'
-
 import { BrowserRouter as Router } from 'react-router-dom'
+
 import EnableAmendment from './mock_data/EnableAmendment.json'
 import Payment from '../../shared/components/Transaction/Payment/test/mock_data/Payment.json'
-import SimpleTab from '../SimpleTab'
+import { SimpleTab } from '../SimpleTab'
 import summarize from '../../../rippled/lib/txSummary'
 import i18n from '../../../i18n/testConfig'
 import { expectSimpleRowText } from '../../shared/components/Transaction/test'
@@ -15,8 +15,6 @@ describe('SimpleTab container', () => {
       <Router>
         <I18nextProvider i18n={i18n}>
           <SimpleTab
-            t={(s) => s}
-            language="en-US"
             data={{ raw: tx, summary: summarize(tx, true).details }}
             width={width}
           />

--- a/src/containers/Validators/SimpleTab.tsx
+++ b/src/containers/Validators/SimpleTab.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
-import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
+import { FC } from 'react'
 import { localizeDate, BREAKPOINTS } from '../shared/utils'
 import Simple from './Simple'
 import '../shared/css/simpleTab.scss'
@@ -22,12 +22,10 @@ const DATE_OPTIONS = {
   timeZone: TIME_ZONE,
 }
 
-export interface SimpleTabProps {
+export const SimpleTab: FC<{
   data: ValidatorSupplemented
   width: number
-}
-
-const SimpleTab = ({ data, width }: SimpleTabProps) => {
+}> = ({ data, width }) => {
   const language = useLanguage()
   const { t } = useTranslation()
 
@@ -76,19 +74,3 @@ const SimpleTab = ({ data, width }: SimpleTabProps) => {
     </div>
   )
 }
-
-// TODO: Remove in the next PR
-SimpleTab.propTypes = {
-  width: PropTypes.number.isRequired,
-  data: PropTypes.objectOf(
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-      PropTypes.number,
-      PropTypes.array,
-      PropTypes.bool,
-    ]),
-  ).isRequired,
-}
-
-export default SimpleTab

--- a/src/containers/Validators/index.tsx
+++ b/src/containers/Validators/index.tsx
@@ -16,7 +16,7 @@ import {
   SERVER_ERROR,
 } from '../shared/utils'
 import { getLedger } from '../../rippled'
-import SimpleTab from './SimpleTab'
+import { SimpleTab } from './SimpleTab'
 import { HistoryTab } from './HistoryTab'
 import './validator.scss'
 import SocketContext from '../shared/SocketContext'

--- a/src/containers/Validators/test/HistoryTab.test.tsx
+++ b/src/containers/Validators/test/HistoryTab.test.tsx
@@ -9,7 +9,6 @@ import { ValidatorReport } from '../../shared/vhsTypes'
 describe(`HistoryTab:`, () => {
   const createWrapper = (reports?: ValidatorReport[]) =>
     mount(
-      // eslint-disable-next-line react/jsx-no-undef
       <I18nextProvider i18n={i18n}>
         <HistoryTab reports={reports} />
       </I18nextProvider>,

--- a/src/containers/Validators/test/SimpleTab.test.tsx
+++ b/src/containers/Validators/test/SimpleTab.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme'
 import { I18nextProvider } from 'react-i18next'
 import { BrowserRouter as Router } from 'react-router-dom'
-import SimpleTab from '../SimpleTab'
+import { SimpleTab } from '../SimpleTab'
 import {
   expectSimpleRowLabel,
   expectSimpleRowText,
@@ -14,19 +14,18 @@ describe('SimpleTab container', () => {
       <I18nextProvider i18n={i18n}>
         <Router>
           <SimpleTab
-            t={i18n.t}
-            language="en-US"
             data={{
               master_key:
                 'nHUvzia57LRXr9zqnYpyFUFeKvis2tqn4DkXBVGSppt5M4nNq43C',
               signing_key:
                 'n9KNmrXo9gK3ucZy8KHKFM113ENGv6uyukS6Bb7TtuvEx98SdwMS',
+              validation_public_key:
+                'nHUvzia57LRXr9zqnYpyFUFeKvis2tqn4DkXBVGSppt5M4nNq43C',
               ledger_hash:
                 'D498209A1B1BBACB9D7C8419F9A4136E7F7748E66B7936D2F92249A2C1AFBCB9',
               current_index: 55764842,
-              load_fee: null,
               partial: false,
-              chain: null,
+              chain: '',
               unl: 'vl.ripple.com',
               last_ledger_time: '2020-05-28T09:21:19.000Z',
               server_version: '1.9.4',
@@ -34,11 +33,13 @@ describe('SimpleTab container', () => {
                 score: '1.00000',
                 missed: 0,
                 incomplete: false,
+                total: 917,
               },
               agreement_24h: {
                 score: '1.00000',
                 missed: 0,
                 incomplete: true,
+                total: 22184,
               },
               agreement_30day: {
                 score: '0.99844',

--- a/src/containers/shared/Interfaces.tsx
+++ b/src/containers/shared/Interfaces.tsx
@@ -41,3 +41,8 @@ export interface ErrorMessage {
   title: string
   hints: string[]
 }
+
+export type ErrorMessages = {
+  default: ErrorMessage
+  [code: number]: ErrorMessage
+}

--- a/src/containers/shared/vhsTypes.ts
+++ b/src/containers/shared/vhsTypes.ts
@@ -80,14 +80,14 @@ export interface ValidatorResponse {
   // eslint-disable-next-line camelcase -- from VHS
   agreement_30day: ValidatorScore | null
   partial: boolean
-  unl: boolean
+  unl: string
 }
 
 export interface ValidatorSupplemented extends ValidatorResponse {
   // eslint-disable-next-line camelcase -- mimicking rippled
   ledger_hash: string
   // eslint-disable-next-line camelcase -- mimicking rippled
-  last_ledger_time: number
+  last_ledger_time: string
 }
 
 export interface StreamValidator extends ValidatorResponse {


### PR DESCRIPTION
## High Level Overview of Change

The title says it all.

### Context of Change

The files that weren't switched to typescript was because doing so would cause lost git history because too much would have changed. This will be done in future PRs.

This also required updating some types that were wrong. All of the `any` types were done because it was already set to a prop type of essentially any.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### TypeScript/Hooks Update

- [x] Updated files to React Hooks
- [x] Updated files to TypeScript
