### PR TITLE
refactor: remove `localizeBalance` method and use `Amount` instead

### DIFF
--- a/src/containers/shared/components/Transaction/AMMBid/Simple.tsx
+++ b/src/containers/shared/components/Transaction/AMMBid/Simple.tsx
@@ -17,12 +17,12 @@ export const Simple = ({ data }: TransactionSimpleProps) => {
       )}
       {bidMin && (
         <SimpleRow label={t('min_slot_price')} data-test="min_slot_price">
-          <Amount value={bidMin} displayIssuer={false} />
+          <Amount value={bidMin} />
         </SimpleRow>
       )}
       {bidMax && (
         <SimpleRow label={t('max_slot_price')} data-test="max_slot_price">
-          <Amount value={bidMax} displayIssuer={false} />
+          <Amount value={bidMax} />
         </SimpleRow>
       )}
       {authAccounts && (

--- a/src/containers/shared/components/Transaction/AMMBid/Simple.tsx
+++ b/src/containers/shared/components/Transaction/AMMBid/Simple.tsx
@@ -1,14 +1,12 @@
 import { useTranslation } from 'react-i18next'
 import { SimpleRow } from '../SimpleRow'
 import { TransactionSimpleProps } from '../types'
-import { localizeBalance } from '../../../utils'
 import { Account } from '../../Account'
+import { Amount } from '../../Amount'
 
 export const Simple = ({ data }: TransactionSimpleProps) => {
   const { t } = useTranslation()
   const { ammAccountID, bidMin, bidMax, authAccounts } = data.instructions
-  const localizedBidMin = localizeBalance(bidMin)
-  const localizedBidMax = localizeBalance(bidMax)
 
   return (
     <>
@@ -17,14 +15,14 @@ export const Simple = ({ data }: TransactionSimpleProps) => {
           <Account account={ammAccountID} />
         </SimpleRow>
       )}
-      {localizedBidMin && (
+      {bidMin && (
         <SimpleRow label={t('min_slot_price')} data-test="min_slot_price">
-          {localizedBidMin}
+          <Amount value={bidMin} displayIssuer={false} />
         </SimpleRow>
       )}
-      {localizedBidMax && (
+      {bidMax && (
         <SimpleRow label={t('max_slot_price')} data-test="max_slot_price">
-          {localizedBidMax}
+          <Amount value={bidMax} displayIssuer={false} />
         </SimpleRow>
       )}
       {authAccounts && (

--- a/src/containers/shared/components/Transaction/AMMBid/test/AMMBid.test.tsx
+++ b/src/containers/shared/components/Transaction/AMMBid/test/AMMBid.test.tsx
@@ -7,8 +7,8 @@ describe('AMM Bid Tests', () => {
 
   it('renders from transaction', () => {
     const wrapper = createWrapper(bidMock)
-    expectSimpleRowText(wrapper, 'min_slot_price', 'LP 100')
-    expectSimpleRowText(wrapper, 'max_slot_price', 'LP 500')
+    expectSimpleRowText(wrapper, 'min_slot_price', '100.00 LP')
+    expectSimpleRowText(wrapper, 'max_slot_price', '500.00 LP')
     expectSimpleRowText(
       wrapper,
       'account_id',

--- a/src/containers/shared/components/Transaction/AMMBid/test/AMMBid.test.tsx
+++ b/src/containers/shared/components/Transaction/AMMBid/test/AMMBid.test.tsx
@@ -7,8 +7,16 @@ describe('AMM Bid Tests', () => {
 
   it('renders from transaction', () => {
     const wrapper = createWrapper(bidMock)
-    expectSimpleRowText(wrapper, 'min_slot_price', '100.00 LP')
-    expectSimpleRowText(wrapper, 'max_slot_price', '500.00 LP')
+    expectSimpleRowText(
+      wrapper,
+      'min_slot_price',
+      '100.00 LP.rMEdVzU8mtEArzjrN9avm3kA675GX7ez8W',
+    )
+    expectSimpleRowText(
+      wrapper,
+      'max_slot_price',
+      '500.00 LP.rMEdVzU8mtEArzjrN9avm3kA675GX7ez8W',
+    )
     expectSimpleRowText(
       wrapper,
       'account_id',

--- a/src/containers/shared/test/utils.test.js
+++ b/src/containers/shared/test/utils.test.js
@@ -9,7 +9,6 @@ import {
   ANALYTIC_TYPES,
   durationToHuman,
   formatAsset,
-  localizeBalance,
 } from '../utils'
 
 describe('utils', () => {
@@ -199,21 +198,5 @@ describe('AMM utils format asset', () => {
     const formatted = formatAsset(asset)
 
     expect(formatted).toEqual({ currency: 'USD', issuer: 'your mom' })
-  })
-})
-
-describe('AMM utils localize balance', () => {
-  it('formats XRP balance', () => {
-    const balance = { currency: 'XRP', amount: 9000000 }
-    const formatted = localizeBalance(balance, 'en-US')
-
-    expect(formatted).toEqual('\uE9009,000,000')
-  })
-
-  it('formats non XRP balance', () => {
-    const balance = { currency: 'USD', amount: 9000000 }
-    const formatted = localizeBalance(balance, 'en-US')
-
-    expect(formatted).toEqual('USD $9,000,000')
   })
 })

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -335,29 +335,6 @@ export const formatAsset = (asset) =>
         issuer: asset.issuer,
       }
 
-export const localizeBalance = (balance, language) => {
-  if (balance === undefined) {
-    return undefined
-  }
-
-  let b = localizeNumber(balance.amount || 0.0, language, {
-    style: 'currency',
-    currency: balance.currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  })
-
-  if (
-    balance.currency !== 'XRP' &&
-    balance.currency !== 'BTC' &&
-    balance.currency !== 'ETH'
-  ) {
-    b = `${balance.currency} ${b}`
-  }
-
-  return b
-}
-
 export const formatTradingFee = (tradingFee) =>
   tradingFee !== undefined
     ? localizeNumber(tradingFee / TRADING_FEE_TOTAL, 'en-US', {


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

The method was unnecessary. See the discussion in #720 for more details.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
![image](https://github.com/ripple/explorer/assets/8029314/121d5ded-3d5e-48fb-bc8b-7a34fb36a771)

After:
![image](https://github.com/ripple/explorer/assets/8029314/a9c5a788-f0c4-4ca4-9200-207cee2a9ea3)

## Test Plan

CI passes after minorly adjusting tests. I don't have a test account to make sure this works as intended locally.
