### PR TITLE
refactor: use `classnames` in place of `clsx`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "buffer": "^6.0.3",
         "bunyan": "^1.8.15",
         "classnames": "^2.3.1",
-        "clsx": "^1.2.1",
         "compression": "^1.7.4",
         "create-hash": "^1.2.0",
         "d3": "^7.8.4",
@@ -7564,13 +7563,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -31091,9 +31083,6 @@
           }
         }
       }
-    },
-    "clsx": {
-      "version": "1.2.1"
     },
     "co": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "buffer": "^6.0.3",
     "bunyan": "^1.8.15",
     "classnames": "^2.3.1",
-    "clsx": "^1.2.1",
     "compression": "^1.7.4",
     "create-hash": "^1.2.0",
     "d3": "^7.8.4",

--- a/src/containers/shared/components/DomainLink.tsx
+++ b/src/containers/shared/components/DomainLink.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx'
+import classnames from 'classnames'
 import { decodeHex } from '../transactionUtils'
 
 export interface Props {
@@ -11,7 +11,7 @@ const DomainLink = (props: Props) => {
   const { className, decode = false, domain } = props
   return (
     <a
-      className={clsx(`domain`, className)}
+      className={classnames(`domain`, className)}
       rel="noopener noreferrer"
       target="_blank"
       href={`https://${decode ? decodeHex(domain) : domain}`}

--- a/src/containers/shared/components/Transaction/SimpleRow.tsx
+++ b/src/containers/shared/components/Transaction/SimpleRow.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import clsx from 'clsx'
+import classnames from 'classnames'
 
 export type SimpleRowProps = PropsWithChildren<{
   className?: string
@@ -11,7 +11,7 @@ export const SimpleRow = (props: SimpleRowProps) => {
   return (
     <div className="row">
       <div className="label">{label}</div>
-      <div className={clsx(`value`, className)}>{children}</div>
+      <div className={classnames(`value`, className)}>{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
## High Level Overview of Change

Title says it all. This removes a dependency.

### Context of Change

https://github.com/ripple/explorer/pull/716#discussion_r1213233976

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### TypeScript/Hooks Update

N/A

## Before / After

No change.

## Test Plan

CI passes. Works locally.
