### PR TITLE
fix: AMM account header too small for <900px width

### DIFF
--- a/src/containers/Accounts/AMM/AMMAccounts/AMMAccountHeader/AMMAccountHeader.tsx
+++ b/src/containers/Accounts/AMM/AMMAccounts/AMMAccountHeader/AMMAccountHeader.tsx
@@ -56,21 +56,23 @@ export const AMMAccountHeader = (props: { data: AmmDataType }) => {
   return (
     <div className="box account-header">
       <div className="section box-header">
-        <div className="title">Account ID</div>
-        <h2 className="amm">{accountId}</h2>
-        <div className="currency-pair">
-          <Currency
-            currency={balance.currency}
-            issuer={balance.issuer}
-            shortenIssuer
-          />
-          /
-          <Currency
-            currency={balance2.currency}
-            issuer={balance2.issuer}
-            shortenIssuer
-          />
+        <div className="title">
+          Account ID
+          <div className="currency-pair">
+            <Currency
+              currency={balance.currency}
+              issuer={balance.issuer}
+              shortenIssuer
+            />
+            /
+            <Currency
+              currency={balance2.currency}
+              issuer={balance2.issuer}
+              shortenIssuer
+            />
+          </div>
         </div>
+        <h1 className="classic">{accountId}</h1>
       </div>
       <div className="box-content">{renderHeaderContent()}</div>
     </div>

--- a/src/containers/Accounts/AccountHeader/styles.scss
+++ b/src/containers/Accounts/AccountHeader/styles.scss
@@ -55,6 +55,7 @@
       border-style: solid;
       border-color: $black-70;
       margin: 0;
+      margin-left: 12px;
       color: $white;
       font-size: 16px;
       @include semibold;


### PR DESCRIPTION
## High Level Overview of Change

Title says it all. Fixes #718 

### Context of Change

Noticed while closing old tabs

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
![image](https://github.com/ripple/explorer/assets/8029314/4b6a43d4-6ed9-4682-93bb-47dc093f42c8)

After:
<img width="872" alt="image" src="https://github.com/ripple/explorer/assets/8029314/8394755b-147a-42fe-91da-1cc97dc203ba">

## Test Plan
Works locally.
