### PR TITLE
test: use `flushPromises` utility

### DIFF
--- a/src/containers/Accounts/AMM/AMMAccounts/AMMAccountHeader/test/AMMAccountHeader.test.tsx
+++ b/src/containers/Accounts/AMM/AMMAccounts/AMMAccountHeader/test/AMMAccountHeader.test.tsx
@@ -3,6 +3,7 @@ import { I18nextProvider } from 'react-i18next'
 import { MemoryRouter } from 'react-router'
 import i18n from '../../../../../../i18n/testConfig'
 import { AMMAccountHeader, AmmDataType } from '../AMMAccountHeader'
+import { flushPromises } from '../../../../../test/utils'
 
 describe('AMM Account Header', () => {
   const TEST_ACCOUNT_ID = 'rTEST_ACCOUNT'
@@ -42,7 +43,3 @@ describe('AMM Account Header', () => {
     wrapper.unmount()
   })
 })
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}

--- a/src/containers/Accounts/AMM/AMMAccounts/test/AMMAccounts.test.tsx
+++ b/src/containers/Accounts/AMM/AMMAccounts/test/AMMAccounts.test.tsx
@@ -9,10 +9,7 @@ import { AMMAccountHeader } from '../AMMAccountHeader/AMMAccountHeader'
 import { AccountTransactionTable } from '../../../AccountTransactionTable'
 import { AMMAccounts } from '../index'
 import { testQueryClient } from '../../../../test/QueryClient'
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
+import { flushPromises } from '../../../../test/utils'
 
 function setSpy(accountTransactions: any, ammInfo: any) {
   const spyInfo = jest.spyOn(rippled, 'getAMMInfo')

--- a/src/containers/Accounts/AccountNFTTable/test/AccountNFTtable.test.jsx
+++ b/src/containers/Accounts/AccountNFTTable/test/AccountNFTtable.test.jsx
@@ -7,15 +7,12 @@ import { AccountNFTTable } from '../AccountNFTTable'
 import i18n from '../../../../i18n/testConfig'
 import { EmptyMessageTableRow } from '../../../shared/EmptyMessageTableRow'
 import { testQueryClient } from '../../../test/QueryClient'
+import { flushPromises } from '../../../test/utils'
 
 jest.mock('../../../../rippled/lib/rippled', () => ({
   __esModule: true,
   getAccountNFTs: jest.fn(),
 }))
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 const mockedGetAccountNFTs = getAccountNFTs
 

--- a/src/containers/Accounts/AccountTransactionTable/test/AccountTransactionTable.test.js
+++ b/src/containers/Accounts/AccountTransactionTable/test/AccountTransactionTable.test.js
@@ -7,6 +7,7 @@ import { AccountTransactionTable } from '../index'
 import TEST_TRANSACTIONS_DATA from './mockTransactions.json'
 import { getAccountTransactions } from '../../../../rippled'
 import { testQueryClient } from '../../../test/QueryClient'
+import { flushPromises } from '../../../test/utils'
 
 jest.mock('../../../../rippled', () => ({
   __esModule: true,
@@ -14,10 +15,6 @@ jest.mock('../../../../rippled', () => ({
 }))
 
 const TEST_ACCOUNT_ID = 'rTEST_ACCOUNT'
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 describe('AccountTransactionsTable container', () => {
   beforeEach(() => {

--- a/src/containers/App/test/App.test.js
+++ b/src/containers/App/test/App.test.js
@@ -10,6 +10,7 @@ import i18n from '../../../i18n/testConfig'
 import { AppWrapper } from '../index'
 import MockWsClient from '../../test/mockWsClient'
 import { getAccountInfo } from '../../../rippled'
+import { flushPromises } from '../../test/utils'
 
 // We need to mock `react-router-dom` because otherwise the BrowserRouter in `App` will
 // get confused about being inside another Router (the `MemoryRouter` in the `mount`),
@@ -43,10 +44,6 @@ jest.mock('../../../rippled', () => {
 
 const mockXrplClient = XrplClient
 const mockGetAccountInfo = getAccountInfo
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 describe('App container', () => {
   const mockStore = configureMockStore()

--- a/src/containers/Header/test/Search.test.js
+++ b/src/containers/Header/test/Search.test.js
@@ -6,6 +6,7 @@ import { Search } from '../Search'
 import * as rippled from '../../../rippled/lib/rippled'
 import SocketContext from '../../shared/SocketContext'
 import MockWsClient from '../../test/mockWsClient'
+import { flushPromises } from '../../test/utils'
 
 describe('Search component', () => {
   const createWrapper = () => {
@@ -37,7 +38,6 @@ describe('Search component', () => {
   })
 
   it('search values', async () => {
-    const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
     const wrapper = createWrapper()
     const input = wrapper.find('.search input')
     const ledgerIndex = '123456789'

--- a/src/containers/Ledger/test/Ledger.test.js
+++ b/src/containers/Ledger/test/Ledger.test.js
@@ -8,6 +8,7 @@ import { Ledger } from '../index'
 import { getLedger } from '../../../rippled'
 import { testQueryClient } from '../../test/QueryClient'
 import { Error as RippledError } from '../../../rippled/lib/utils'
+import { flushPromises } from '../../test/utils'
 
 jest.mock('../../../rippled', () => {
   const originalModule = jest.requireActual('../../../rippled')
@@ -20,10 +21,6 @@ jest.mock('../../../rippled', () => {
 })
 
 const mockedGetLedger = getLedger
-
-export function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 describe('Ledger container', () => {
   const createWrapper = (identifier = 38079857) =>

--- a/src/containers/PayStrings/test/index.test.js
+++ b/src/containers/PayStrings/test/index.test.js
@@ -7,6 +7,7 @@ import { PayString } from '../index'
 import { getPayString } from '../../../rippled'
 import { testQueryClient } from '../../test/QueryClient'
 import mockPayStringData from './mockPayStringData.json'
+import { flushPromises } from '../../test/utils'
 
 jest.mock('../../../rippled', () => {
   const originalModule = jest.requireActual('../../../rippled')
@@ -19,10 +20,6 @@ jest.mock('../../../rippled', () => {
 })
 
 const mockGetPayString = getPayString
-
-export function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 describe('PayString container', () => {
   const TEST_PAY_ID = 'blunden$paystring.crypto.com'

--- a/src/containers/Token/TokenTransactionTable/test/TokenTransactionTable.test.js
+++ b/src/containers/Token/TokenTransactionTable/test/TokenTransactionTable.test.js
@@ -8,6 +8,7 @@ import TEST_TRANSACTIONS_DATA from '../../../Accounts/AccountTransactionTable/te
 
 import { getAccountTransactions } from '../../../../rippled'
 import { testQueryClient } from '../../../test/QueryClient'
+import { flushPromises } from '../../../test/utils'
 
 jest.mock('../../../../rippled', () => ({
   __esModule: true,
@@ -16,10 +17,6 @@ jest.mock('../../../../rippled', () => ({
 
 const TEST_ACCOUNT_ID = 'rTEST_ACCOUNT'
 const TEST_CURRENCY = 'abc'
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 describe('TokenTransactionsTable container', () => {
   const createWrapper = (

--- a/src/containers/Validators/test/Validator.test.js
+++ b/src/containers/Validators/test/Validator.test.js
@@ -9,6 +9,7 @@ import { Validator } from '../index'
 import { getLedger } from '../../../rippled'
 import { testQueryClient } from '../../test/QueryClient'
 import NetworkContext from '../../shared/NetworkContext'
+import { flushPromises } from '../../test/utils'
 
 global.location = '/validators/aaaa'
 
@@ -23,10 +24,6 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(),
 }))
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 describe('Validator container', () => {
   const createWrapper = (props = {}) => {

--- a/src/containers/shared/components/Transaction/EnableAmendment/test/EnableAmendmentSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/EnableAmendment/test/EnableAmendmentSimple.test.tsx
@@ -10,6 +10,7 @@ import {
   getRippledVersion,
   nameOfAmendmentID,
 } from '../../../../amendmentUtils'
+import { flushPromises } from '../../../../../test/utils'
 
 const createWrapper = createSimpleWrapperFactory(Simple, i18n)
 
@@ -23,10 +24,6 @@ jest.mock('../../../../amendmentUtils', () => {
     nameOfAmendmentID: jest.fn(),
   }
 })
-
-function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve))
-}
 
 const mockedGetRippledVersion = getRippledVersion as jest.MockedFunction<
   typeof getRippledVersion


### PR DESCRIPTION
## High Level Overview of Change

Removes many redefinitions of `flushPromises`.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)