### PR TITLE
fix: sequence and account for UNLModify

### DIFF
--- a/src/containers/Transactions/SimpleTab.tsx
+++ b/src/containers/Transactions/SimpleTab.tsx
@@ -49,9 +49,11 @@ export const SimpleTab: FC<{ data: any; width: number }> = ({
       <SimpleRow label={t('ledger_index')} data-test="ledger-index">
         <Link to={`/ledgers/${ledgerIndex}`}>{ledgerIndex}</Link>
       </SimpleRow>
-      <SimpleRow label={t('account')} data-test="account">
-        <Account account={account} />
-      </SimpleRow>
+      {account && (
+        <SimpleRow label={t('account')} data-test="account">
+          <Account account={account} />
+        </SimpleRow>
+      )}
       <SimpleRow label={t('sequence_number')} data-test="sequence">
         <Sequence
           sequence={sequence}

--- a/src/containers/shared/components/Sequence.tsx
+++ b/src/containers/shared/components/Sequence.tsx
@@ -16,7 +16,7 @@ export const Sequence: FC<SequenceProps> = ({
   account = '',
 }) => {
   const { t } = useTranslation()
-  const isPseudoTransaction = account === ACCOUNT_ZERO
+  const isPseudoTransaction = account === ACCOUNT_ZERO || account === ''
 
   return (
     <span>

--- a/src/containers/shared/components/Transaction/UNLModify/test/UNLModifySimple.test.tsx
+++ b/src/containers/shared/components/Transaction/UNLModify/test/UNLModifySimple.test.tsx
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme'
 import i18n from '../../../../../../i18n/testConfigEnglish'
 import { expectSimpleRowLabel, expectSimpleRowText } from '../../test'
 import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
@@ -5,6 +6,9 @@ import { createSimpleWrapperFactory } from '../../test/createWrapperFactory'
 import { Simple } from '../Simple'
 import mockUNLModifyEnable from './mock_data/UNLModifyEnable.json'
 import mockUNLModifyDisable from './mock_data/UNLModifyDisable.json'
+import { SimpleTab } from '../../../../../Transactions/SimpleTab'
+import { QuickHarness } from '../../../../../test/utils'
+import summarizeTransaction from '../../../../../../rippled/lib/txSummary'
 
 const createWrapper = createSimpleWrapperFactory(Simple, i18n)
 
@@ -32,6 +36,25 @@ describe('UNLModify: Simple', () => {
     )
     expectSimpleRowLabel(wrapper, 'action', 'action')
     expectSimpleRowText(wrapper, 'action', 'DISABLE')
+    wrapper.unmount()
+  })
+
+  it('renders tx with correct account and sequence', () => {
+    const wrapper = mount(
+      <QuickHarness i18n={i18n}>
+        <SimpleTab
+          data={{
+            raw: mockUNLModifyDisable,
+            summary: summarizeTransaction(mockUNLModifyDisable, true).details,
+          }}
+          width={800}
+        />
+      </QuickHarness>,
+    )
+    expect(wrapper.find('[data-test="account"]')).not.toExist()
+    expectSimpleRowLabel(wrapper, 'sequence', 'Sequence Number')
+    expectSimpleRowText(wrapper, 'sequence', '0')
+
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

The sequence was saying that it used a ticket and account was blank. Now Account will be hidden since it is blank.

Fixes #477

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before
![UNLModify](https://user-images.githubusercontent.com/464895/204333916-de1c9f5a-5f41-4f1e-bc76-e4b2420789ce.png)

## After
![Monosnap XRPL Explorer | TX 0746806B  2023-06-15 16-27-52](https://github.com/ripple/explorer/assets/464895/9cb78ee2-ea4d-4af9-a960-91700bf822a2)

