### PR TITLE
fix: remove `x` buttons from non-custom networks

### DIFF
--- a/src/containers/Header/NetworkPicker/NetworkPicker.tsx
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.tsx
@@ -141,9 +141,9 @@ export const NetworkPicker = () => {
         {networks.map(({ network, title, url = '' }) => {
           if (
             // we are not in custom mode and it's this network
-            (currentMode !== 'custom' && network === currentMode) ||
+            (!isCustom && network === currentMode) ||
             // we are in custom mode and it's this URL
-            (currentMode === 'custom' && url === `/${rippledUrl}`) ||
+            (isCustom && url === `/${rippledUrl}`) ||
             // the href of this window contains this URL
             window.location.href?.indexOf(url) === 0
           ) {

--- a/src/containers/Header/NetworkPicker/NetworkPicker.tsx
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.tsx
@@ -43,9 +43,10 @@ export const NetworkPicker = () => {
   const trackNetworkSwitch = (network, url) => {
     track('network_switch', {
       network,
-      entrypoint: isCustom
-        ? url?.replace(`${CUSTOM_NETWORK_BASE_LINK || ''}/`, '')
-        : undefined,
+      entrypoint:
+        network === 'custom'
+          ? url?.replace(`${CUSTOM_NETWORK_BASE_LINK || ''}/`, '')
+          : undefined,
     })
   }
 
@@ -79,7 +80,7 @@ export const NetworkPicker = () => {
         handler={handleNetworkClick(network, url)}
       >
         {text}
-        {isCustom && (
+        {network === 'custom' && (
           <button
             type="button"
             className="btn btn-remove"

--- a/src/containers/Header/NetworkPicker/test/NetworkPicker.test.tsx
+++ b/src/containers/Header/NetworkPicker/test/NetworkPicker.test.tsx
@@ -141,5 +141,9 @@ describe('NetworkPicker component', () => {
       'href',
       `${process.env.VITE_CUSTOMNETWORK_LINK}/custom_url2`,
     )
+    expect(wrapper.find('.dropdown-item.custom .btn-remove').length).toEqual(2)
+
+    expect(wrapper.find('.dropdown-item.testnet')).toExist()
+    expect(wrapper.find('.dropdown-item.testnet .btn-remove')).not.toExist()
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

Noticed by @ckniffen 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

Before:
<img width="423" alt="image" src="https://github.com/ripple/explorer/assets/8029314/88276e55-f88b-4803-be38-d213ddfed9af">

After:
<img width="423" alt="image" src="https://github.com/ripple/explorer/assets/8029314/c6537ab3-2fc9-45dc-a58f-0e494bced312">

## Test Plan

Works locally. Fixed the test to check for this.