### PR TITLE
fix: deleted accounts showed as not found

### DIFF
--- a/src/containers/Accounts/AccountHeader/index.tsx
+++ b/src/containers/Accounts/AccountHeader/index.tsx
@@ -395,7 +395,7 @@ const AccountHeader = (props: AccountHeaderProps) => {
           <div className="secondary balance">
             {deleted ? (
               <div className="warning">
-                <InfoIcon alt="Account Deleted" />
+                <InfoIcon alt="Account Deleted" />{' '}
                 <span className="account-deleted-text">Account Deleted</span>
               </div>
             ) : (

--- a/src/containers/Accounts/AccountHeader/test/accountDeletedTransactions.json
+++ b/src/containers/Accounts/AccountHeader/test/accountDeletedTransactions.json
@@ -1,0 +1,156 @@
+{
+  "account_info": {
+    "id": 2,
+    "status": "error",
+    "type": "response",
+    "account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+    "error": "actNotFound",
+    "error_code": 19,
+    "error_message": "Account not found.",
+    "ledger_current_index": 80602456,
+    "request": {
+      "account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+      "command": "account_info",
+      "id": 2,
+      "ledger_index": "current",
+      "queue": true,
+      "strict": true
+    },
+    "validated": false,
+    "forwarded": true,
+    "warnings": [
+      {
+        "id": 2001,
+        "message": "This is a clio server. clio only serves validated data. If you want to talk to rippled, include 'ledger_index':'current' in your request"
+      }
+    ]
+  },
+  "account_tx": {
+    "id": 2,
+    "status": "success",
+    "type": "response",
+    "result": {
+      "account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+      "ledger_index_min": 32570,
+      "ledger_index_max": 80602468,
+      "transactions": [
+        {
+          "meta": {
+            "AffectedNodes": [
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rEoRCpve6aPs6gg2u5aaeCsBmX9ZB7TzhR",
+                    "Balance": "1553170065225",
+                    "Flags": 0,
+                    "OwnerCount": 0,
+                    "Sequence": 80463368
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "856F60BEC3D95BC1035C2D9691CA4CA2FD455FA0D62783F504277374A6966589",
+                  "PreviousFields": {
+                    "Balance": "1553152515225"
+                  },
+                  "PreviousTxnID": "005613ADA8AA0618C62B4EC53C181ED8831E694F24F1B77706DE98218522AADF",
+                  "PreviousTxnLgrSeq": 80537220
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "Account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+                    "Balance": "0",
+                    "Flags": 0,
+                    "OwnerCount": 0,
+                    "PreviousTxnID": "B5180561D25F1D17672F2FCED48E06F3B72D43E33202660BF57647D1914D940A",
+                    "PreviousTxnLgrSeq": 29256436,
+                    "Sequence": 8
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "EAE9EC4DC190D2C0A33E8963D86B48D3A18394B04E2C891176E5A78E1EFD7023",
+                  "PreviousFields": {
+                    "Balance": "19550000",
+                    "Sequence": 7
+                  }
+                }
+              }
+            ],
+            "DeliveredAmount": "17550000",
+            "TransactionIndex": 25,
+            "TransactionResult": "tesSUCCESS",
+            "delivered_amount": "17550000"
+          },
+          "tx": {
+            "Account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+            "Destination": "rEoRCpve6aPs6gg2u5aaeCsBmX9ZB7TzhR",
+            "DestinationTag": 2123456789,
+            "Fee": "2000000",
+            "Flags": 2147483648,
+            "Sequence": 7,
+            "SigningPubKey": "029D82602618266B98506884CE4C61CECF5504CBCEDA41CED583FE4C6972455C9E",
+            "TransactionType": "AccountDelete",
+            "TxnSignature": "3045022100A95A9508F96B5D979BD2AFE1F667733DDFC06A5BF79C5C085439CB39C4B14B04022074D84F5AB63390565A4D12D313A8D4666370A99F05B0B887505A80F431E18682",
+            "hash": "BB955E1E2DDC4529A79F6DCB9741013B6D218FFBE441871FC466895DD4300F37",
+            "ledger_index": 80537221,
+            "date": 740350911
+          },
+          "validated": true
+        },
+        {
+          "meta": {
+            "AffectedNodes": [
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+                    "Balance": "19550000",
+                    "Flags": 0,
+                    "OwnerCount": 0,
+                    "Sequence": 7
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "EAE9EC4DC190D2C0A33E8963D86B48D3A18394B04E2C891176E5A78E1EFD7023",
+                  "PreviousFields": {
+                    "Balance": "19700000",
+                    "Sequence": 6
+                  },
+                  "PreviousTxnID": "56675612ACAF05BAA0499A0CD2D81E0C2B66C2133A2AC328CE311B0BD8C83401",
+                  "PreviousTxnLgrSeq": 29256433
+                }
+              }
+            ],
+            "TransactionIndex": 22,
+            "TransactionResult": "tecUNFUNDED_PAYMENT"
+          },
+          "tx": {
+            "Account": "r35jYntLwkrbc3edisgavDbEdNRSKgcQE6",
+            "Amount": "4856600000",
+            "Destination": "rDCgaaSBAWYfsxUYhCk1n26Na7x8PQGmkq",
+            "Fee": "150000",
+            "Flags": 2147483648,
+            "Sequence": 6,
+            "SigningPubKey": "029D82602618266B98506884CE4C61CECF5504CBCEDA41CED583FE4C6972455C9E",
+            "TransactionType": "Payment",
+            "TxnSignature": "3045022100D84347CBC15152E08D83AD7F50B29E07548DB142E69D23D7B983AFD71E5AE67F02205EA4717A39120489DA26088BAD9F741D9F2B87A78C863CBED47FE518675B8215",
+            "hash": "B5180561D25F1D17672F2FCED48E06F3B72D43E33202660BF57647D1914D940A",
+            "ledger_index": 29256436,
+            "date": 546295030
+          },
+          "validated": true
+        }
+      ],
+      "validated": true,
+      "marker": {
+        "ledger": 29256436,
+        "seq": 22
+      },
+      "limit": 2
+    },
+    "warnings": [
+      {
+        "id": 2001,
+        "message": "This is a clio server. clio only serves validated data. If you want to talk to rippled, include 'ledger_index':'current' in your request"
+      }
+    ]
+  }
+}

--- a/src/containers/Accounts/AccountHeader/test/actions.test.js
+++ b/src/containers/Accounts/AccountHeader/test/actions.test.js
@@ -5,6 +5,7 @@ import * as actionTypes from '../actionTypes'
 import { initialState } from '../reducer'
 import { NOT_FOUND, BAD_REQUEST, SERVER_ERROR } from '../../../shared/utils'
 import rippledResponses from './rippledResponses.json'
+import accountDeletedTransactions from './accountDeletedTransactions.json'
 import actNotFound from '../../../Token/TokenHeader/test/actNotFound.json'
 import actWithTokens from './accountWithTokens.json'
 import MockWsClient from '../../../test/mockWsClient'
@@ -278,5 +279,34 @@ describe('AccountHeader Actions', () => {
     store.dispatch(actions.loadAccountState('ZZZ', client)).then(() => {
       expect(store.getActions()).toEqual(expectedActions)
     })
+  })
+
+  it('should dispatch correct actions on a deleted account', () => {
+    client.addResponses(accountDeletedTransactions)
+
+    const expectedActions = [
+      {
+        type: 'START_LOADING_ACCOUNT_STATE',
+      },
+      {
+        type: 'FINISHED_LOADING_ACCOUNT_STATE',
+      },
+      {
+        type: actionTypes.ACCOUNT_STATE_LOAD_SUCCESS,
+        data: {
+          account: 'r35jYntLwkrbc3edisgavDbEdNRSKgcQE6',
+          deleted: true,
+          xAddress: undefined,
+        },
+      },
+    ]
+    const store = mockStore({ news: initialState })
+    store
+      .dispatch(
+        actions.loadAccountState('r35jYntLwkrbc3edisgavDbEdNRSKgcQE6', client),
+      )
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions)
+      })
   })
 })

--- a/src/containers/Accounts/AccountsRouter.tsx
+++ b/src/containers/Accounts/AccountsRouter.tsx
@@ -37,12 +37,17 @@ export const AccountsRouter = () => {
       classicAddress = xAddressToClassicAddress(accountId).classicAddress
     }
 
-    return getAccountInfo(rippledSocket, classicAddress).then((data: any) => {
-      if (data.Flags & flags.lsfAMM) {
-        return <AMMAccounts />
-      }
-      return <Accounts />
-    })
+    return (
+      getAccountInfo(rippledSocket, classicAddress)
+        .then((data: any) => {
+          if (data.Flags & flags.lsfAMM) {
+            return <AMMAccounts />
+          }
+          return <Accounts />
+        })
+        // Even if account info fails it might be a deleted account
+        .catch(() => <Accounts />)
+    )
   })
 
   if (!accountId) {

--- a/src/containers/test/mockWsClient.js
+++ b/src/containers/test/mockWsClient.js
@@ -99,7 +99,10 @@ class MockWsClient extends EventEmitter {
       return Promise.reject(new Error({}))
     }
     const { command } = message
-    return Promise.resolve(this.responses[command]?.result)
+    return Promise.resolve(
+      // When an error (no result) return the whole response like xrpl-client does.
+      this.responses[command]?.result || this.responses[command],
+    )
   }
 
   /**


### PR DESCRIPTION
## High Level Overview of Change

This was broken when routing was added for AMM accounts.  `account_info` will fail for a deleted account but `account_tx` will succeed.

Thank you @lathanbritz for finding this bug.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)