### PR TITLE
feat: add hooks testnet support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,11 @@ VITE_MAINNET_LINK=
 VITE_TESTNET_LINK=
 VITE_DEVNET_LINK=
 VITE_AMM_LINK=
-VITE_HOOKS_LINK=
+VITE_HOOKS_TESTNET_LINK=
 VITE_CUSTOMNETWORK_LINK=
 VITE_VALIDATOR=vl.ripple.com
 
-#XRPL Environment: mainnet, testnet, devnet, amm, hooks, custom
+#XRPL Environment: mainnet, testnet, devnet, amm, hooks-testnet, custom
 VITE_ENVIRONMENT=mainnet
 
 #VHS endpoint url

--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,11 @@ VITE_MAINNET_LINK=
 VITE_TESTNET_LINK=
 VITE_DEVNET_LINK=
 VITE_AMM_LINK=
+VITE_HOOKS_LINK=
 VITE_CUSTOMNETWORK_LINK=
 VITE_VALIDATOR=vl.ripple.com
 
-#XRPL Environment: mainnet, testnet, devnet, amm, custom
+#XRPL Environment: mainnet, testnet, devnet, amm, hooks, custom
 VITE_ENVIRONMENT=mainnet
 
 #VHS endpoint url

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ VITE_HOOKS_TESTNET_LINK=
 VITE_CUSTOMNETWORK_LINK=
 VITE_VALIDATOR=vl.ripple.com
 
-#XRPL Environment: mainnet, testnet, devnet, amm, hooks-testnet, custom
+#XRPL Environment: mainnet, testnet, devnet, amm, hooks_testnet, custom
 VITE_ENVIRONMENT=mainnet
 
 #VHS endpoint url

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -11,6 +11,7 @@
   "network_name_mainnet": "Mainnet",
   "network_name_devnet": "Devnet",
   "network_name_amm": "AMM-Devnet",
+  "network_name_hooks": "Hooks-Testnet",
   "network_name_custom": "Custom",
   "app.meta.description": "XRPL Network Explorer",
   "app.meta.author": "Ripple",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -11,7 +11,7 @@
   "network_name_mainnet": "Mainnet",
   "network_name_devnet": "Devnet",
   "network_name_amm": "AMM-Devnet",
-  "network_name_hooks": "Hooks-Testnet",
+  "network_name_hooks-testnet": "Hooks-Testnet",
   "network_name_custom": "Custom",
   "app.meta.description": "XRPL Network Explorer",
   "app.meta.author": "Ripple",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -11,7 +11,7 @@
   "network_name_mainnet": "Mainnet",
   "network_name_devnet": "Devnet",
   "network_name_amm": "AMM-Devnet",
-  "network_name_hooks-testnet": "Hooks-Testnet",
+  "network_name_hooks_testnet": "Hooks-Testnet",
   "network_name_custom": "Custom",
   "app.meta.description": "XRPL Network Explorer",
   "app.meta.author": "Ripple",

--- a/src/containers/Header/NetworkPicker/NetworkPicker.scss
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.scss
@@ -54,8 +54,8 @@
     @include dropdown-network-item($amm, $blue-60);
   }
 
-  &.network-hooks {
-    @include dropdown-network-item($hooks, $red-purple-60);
+  &.network-hooks-testnet {
+    @include dropdown-network-item($hooks-testnet, $red-purple-60);
   }
 
   &.network-custom {

--- a/src/containers/Header/NetworkPicker/NetworkPicker.scss
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.scss
@@ -54,6 +54,7 @@
     @include dropdown-network-item($amm, $blue-60);
   }
 
+  /* stylelint-disable-next-line selector-class-pattern -- needed here for variables */
   &.network-hooks_testnet {
     @include dropdown-network-item($hooks-testnet, $red-purple-60);
   }

--- a/src/containers/Header/NetworkPicker/NetworkPicker.scss
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.scss
@@ -54,6 +54,10 @@
     @include dropdown-network-item($amm, $blue-60);
   }
 
+  &.network-hooks {
+    @include dropdown-network-item($hooks, $red-purple-60);
+  }
+
   &.network-custom {
     @include dropdown-network-item($custom, $yellow-60);
   }

--- a/src/containers/Header/NetworkPicker/NetworkPicker.scss
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.scss
@@ -54,7 +54,7 @@
     @include dropdown-network-item($amm, $blue-60);
   }
 
-  &.network-hooks-testnet {
+  &.network-hooks_testnet {
     @include dropdown-network-item($hooks-testnet, $red-purple-60);
   }
 

--- a/src/containers/Header/NetworkPicker/NetworkPicker.tsx
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.tsx
@@ -18,7 +18,7 @@ const STATIC_ENV_LINKS: Record<string, string | undefined> = {
   testnet: process.env.VITE_TESTNET_LINK,
   devnet: process.env.VITE_DEVNET_LINK,
   amm: process.env.VITE_AMM_LINK,
-  hooks: process.env.VITE_HOOKS_LINK,
+  'hooks-testnet': process.env.VITE_HOOKS_TESTNET_LINK,
 }
 const currentMode: string = process.env.VITE_ENVIRONMENT || 'mainnet'
 

--- a/src/containers/Header/NetworkPicker/NetworkPicker.tsx
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.tsx
@@ -18,6 +18,7 @@ const STATIC_ENV_LINKS: Record<string, string | undefined> = {
   testnet: process.env.VITE_TESTNET_LINK,
   devnet: process.env.VITE_DEVNET_LINK,
   amm: process.env.VITE_AMM_LINK,
+  hooks: process.env.VITE_HOOKS_LINK,
 }
 const currentMode: string = process.env.VITE_ENVIRONMENT || 'mainnet'
 

--- a/src/containers/Header/NetworkPicker/NetworkPicker.tsx
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.tsx
@@ -18,7 +18,7 @@ const STATIC_ENV_LINKS: Record<string, string | undefined> = {
   testnet: process.env.VITE_TESTNET_LINK,
   devnet: process.env.VITE_DEVNET_LINK,
   amm: process.env.VITE_AMM_LINK,
-  'hooks-testnet': process.env.VITE_HOOKS_TESTNET_LINK,
+  hooks_testnet: process.env.VITE_HOOKS_TESTNET_LINK,
 }
 const currentMode: string = process.env.VITE_ENVIRONMENT || 'mainnet'
 

--- a/src/containers/shared/NetworkContext.tsx
+++ b/src/containers/shared/NetworkContext.tsx
@@ -6,9 +6,8 @@ const ENV_NETWORK_MAP: Record<string, string> = {
   mainnet: 'main',
   testnet: 'test',
   devnet: 'dev',
-  nft_sandbox: 'nft-dev',
   amm: 'amm-dev',
-  hooks: 'hooks-test',
+  hooks_testnet: 'hooks-test',
 }
 
 function getNetworkName() {

--- a/src/containers/shared/NetworkContext.tsx
+++ b/src/containers/shared/NetworkContext.tsx
@@ -8,6 +8,7 @@ const ENV_NETWORK_MAP: Record<string, string> = {
   devnet: 'dev',
   nft_sandbox: 'nft-dev',
   amm: 'amm-dev',
+  hooks: 'hooks-test',
 }
 
 function getNetworkName() {

--- a/src/containers/shared/css/variables.scss
+++ b/src/containers/shared/css/variables.scss
@@ -113,7 +113,7 @@ $white-transparent: rgb(255 255 255 / 75%);
 // Networks
 $testnet: $orange;
 $devnet: $blue-purple-30;
-$hooks: $red-purple-40;
+$hooks-testnet: $red-purple-30;
 $custom: $yellow-50;
 
 // Feature Sets

--- a/src/containers/shared/css/variables.scss
+++ b/src/containers/shared/css/variables.scss
@@ -113,6 +113,7 @@ $white-transparent: rgb(255 255 255 / 75%);
 // Networks
 $testnet: $orange;
 $devnet: $blue-purple-30;
+$hooks: $red-purple-40;
 $custom: $yellow-50;
 
 // Feature Sets


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

The Network page won't work until https://github.com/ripple/validator-history-service/pull/94 is merged and deployed.

### Context of Change

Better network support

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### TypeScript/Hooks Update

N/A

Technically adding hooks support 😜 

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Works locally.