### PR TITLE
fix: change hooks testnet network color

### DIFF
--- a/src/containers/Header/NetworkPicker/NetworkPicker.scss
+++ b/src/containers/Header/NetworkPicker/NetworkPicker.scss
@@ -56,7 +56,7 @@
 
   /* stylelint-disable-next-line selector-class-pattern -- needed here for variables */
   &.network-hooks_testnet {
-    @include dropdown-network-item($hooks-testnet, $red-purple-60);
+    @include dropdown-network-item($hooks-testnet, $magenta-40);
   }
 
   &.network-custom {

--- a/src/containers/shared/css/variables.scss
+++ b/src/containers/shared/css/variables.scss
@@ -113,7 +113,7 @@ $white-transparent: rgb(255 255 255 / 75%);
 // Networks
 $testnet: $orange;
 $devnet: $blue-purple-30;
-$hooks-testnet: $red-purple-30;
+$hooks-testnet: $magenta-30;
 $custom: $yellow-50;
 
 // Feature Sets


### PR DESCRIPTION
## High Level Overview of Change

This PR changes the color of the hooks testnet from red-purple to magenta.

### Context of Change

Requested by @bugsbunnies for accessibility purposes

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Works locally.
