### PR TITLE
strip leading and trailing quotes from search

### DIFF
--- a/src/containers/Header/Search.tsx
+++ b/src/containers/Header/Search.tsx
@@ -104,15 +104,17 @@ export const Search = ({ callback = () => {} }: SearchProps) => {
   const history = useHistory()
 
   const handleSearch = async (id: string) => {
-    const type = await getIdType(id, socket)
-
+    const strippedId = id.replace(/^["']|["']$/g, '')
+    const type = await getIdType(strippedId, socket)
     track('search', {
-      search_term: id,
+      search_term: strippedId,
       search_category: type,
     })
 
     history.push(
-      type === 'invalid' ? `/search/${id}` : `/${type}/${normalize(id, type)}`,
+      type === 'invalid'
+        ? `/search/${strippedId}`
+        : `/${type}/${normalize(strippedId, type)}`,
     )
     callback()
   }

--- a/src/containers/Header/test/Search.test.js
+++ b/src/containers/Header/test/Search.test.js
@@ -47,6 +47,9 @@ describe('Search component', () => {
     const paystring = 'blunden$paystring.crypto.com'
     const paystringWithAt = 'blunden@paystring.crypto.com'
     const validator = 'nHUFE9prPXPrHcG3SkwP1UzAQbSphqyQkQK9ATXLZsfkezhhda3p'
+    const addressWithQuotes = '"rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX"'
+    const addressWithSpace = ' rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX '
+    const addressWithSingleQuote = '"rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX'
 
     const hash =
       '59239EA78084F6E2F288473F8AE02F3E6FC92F44BDE59668B5CAE361D3D32838'
@@ -69,6 +72,21 @@ describe('Search component', () => {
     expect(window.location.pathname).toEqual(`/ledgers/${ledgerIndex}`)
 
     input.instance().value = rippleAddress
+    input.simulate('keyDown', { key: 'Enter' })
+    await flushPromises()
+    expect(window.location.pathname).toEqual(`/accounts/${rippleAddress}`)
+
+    input.instance().value = addressWithQuotes
+    input.simulate('keyDown', { key: 'Enter' })
+    await flushPromises()
+    expect(window.location.pathname).toEqual(`/accounts/${rippleAddress}`)
+
+    input.instance().value = addressWithSingleQuote
+    input.simulate('keyDown', { key: 'Enter' })
+    await flushPromises()
+    expect(window.location.pathname).toEqual(`/accounts/${rippleAddress}`)
+
+    input.instance().value = addressWithSpace
     input.simulate('keyDown', { key: 'Enter' })
     await flushPromises()
     expect(window.location.pathname).toEqual(`/accounts/${rippleAddress}`)


### PR DESCRIPTION
## High Level Overview of Change

referring to issue https://github.com/ripple/explorer/issues/392
programmatically strip the quotes  
Before: 
<img width="1394" alt="Screenshot 2023-06-26 at 3 00 43 PM" src="https://github.com/ripple/explorer/assets/9340787/e669ef2c-e4b5-4125-8faa-6df292b2c260">


after:
<img width="1480" alt="Screenshot 2023-06-26 at 3 00 06 PM" src="https://github.com/ripple/explorer/assets/9340787/3d0edfb1-5594-48c3-b236-379143913bf9">

