### PR TITLE
fix: show error for malformed accounts

### DIFF
--- a/src/containers/App/test/App.test.jsx
+++ b/src/containers/App/test/App.test.jsx
@@ -267,22 +267,42 @@ describe('App container', () => {
   })
 
   it('renders account page for classic address', () => {
-    const id = 'rZaChweF5oXn'
+    const id = 'rKV8HEL3vLc6q9waTiJcewdRdSFyx67QFb'
     const wrapper = createWrapper(`/accounts/${id}#ssss`)
     flushPromises()
     flushPromises()
     return new Promise((r) => setTimeout(r, 200)).then(() => {
-      expect(document.title).toEqual(`xrpl_explorer | ${id}...`)
+      expect(document.title).toEqual(`xrpl_explorer | rKV8HEL3vLc6...`)
       expect(window.dataLayer).toEqual([
         {
-          page_path: '/accounts/rZaChweF5oXn#ssss',
-          page_title: 'xrpl_explorer | rZaChweF5oXn...',
+          page_path: '/accounts/rKV8HEL3vLc6q9waTiJcewdRdSFyx67QFb#ssss',
+          page_title: 'xrpl_explorer | rKV8HEL3vLc6...',
           event: 'screen_view',
           network: 'mainnet',
         },
       ])
       wrapper.unmount()
     })
+  })
+
+  it('renders account page for malformed', async () => {
+    const id = 'rZaChweF5oXn'
+    const wrapper = createWrapper(`/accounts/${id}#ssss`)
+    await flushPromises()
+    await flushPromises()
+    wrapper.update()
+    expect(document.title).toEqual(`xrpl_explorer | invalid_xrpl_address`)
+    expect(window.dataLayer).toEqual([
+      {
+        page_path: '/accounts/rZaChweF5oXn#ssss',
+        description: 'invalid_xrpl_address -- check_account_id',
+        event: 'not_found',
+        network: 'mainnet',
+      },
+    ])
+    expect(wrapper.find('.no-match .title')).toHaveText('invalid_xrpl_address')
+    expect(wrapper.find('.no-match .hint')).toHaveText('check_account_id')
+    wrapper.unmount()
   })
 
   it('renders account page for a deleted account', () => {
@@ -373,14 +393,14 @@ describe('App container', () => {
   })
 
   it('redirects legacy account page', () => {
-    const id = 'rZaChweF5oXn'
+    const id = 'rKV8HEL3vLc6q9waTiJcewdRdSFyx67QFb'
     const wrapper = createWrapper(`/#/graph/${id}#ssss`)
     return new Promise((r) => setTimeout(r, 200)).then(() => {
-      expect(document.title).toEqual(`xrpl_explorer | ${id}...`)
+      expect(document.title).toEqual(`xrpl_explorer | rKV8HEL3vLc6...`)
       expect(window.dataLayer).toEqual([
         {
-          page_path: '/accounts/rZaChweF5oXn#ssss',
-          page_title: 'xrpl_explorer | rZaChweF5oXn...',
+          page_path: '/accounts/rKV8HEL3vLc6q9waTiJcewdRdSFyx67QFb#ssss',
+          page_title: 'xrpl_explorer | rKV8HEL3vLc6...',
           event: 'screen_view',
           network: 'mainnet',
         },


### PR DESCRIPTION
## High Level Overview of Change

Let the user know when they directly hit the account page with a malformed account address.

### Context of Change

This was broken when the AMM account support was added

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before
![Monosnap XRPL Explorer | rZaChweF5oXn  2023-07-03 16-02-38](https://github.com/ripple/explorer/assets/464895/3c39f7d0-9905-41c5-b1da-0aadb57c2601)

## After
![Monosnap XRPL Explorer | Invalid XRPL address 2023-07-03 16-01-55](https://github.com/ripple/explorer/assets/464895/20f097a6-27cb-4691-b04c-713b791d9308)