### PR TITLE
fix: legacy redirect for accounts

### DIFF
--- a/src/containers/App/legacyRedirects.tsx
+++ b/src/containers/App/legacyRedirects.tsx
@@ -9,9 +9,13 @@ export const legacyRedirect = (
       const identifier = location.hash.split('#/transactions/')[1]
       return `${basename}/transactions/${identifier}`
     }
-    if (location.hash.indexOf('#/graph/') === 0) {
+    if (location.hash.indexOf('#/graph') === 0) {
       const identifier = location.hash.split('#/graph/')[1]
-      return `${basename}/accounts/${identifier}`
+      if (identifier) {
+        return `${basename}/accounts/${identifier}`
+      }
+
+      return `${basename}/`
     }
   }
 

--- a/src/containers/App/test/App.test.jsx
+++ b/src/containers/App/test/App.test.jsx
@@ -391,6 +391,21 @@ describe('App container', () => {
     })
   })
 
+  it('redirects legacy account page with no account', () => {
+    wrapper = createWrapper(`/#/graph/`)
+    return new Promise((r) => setTimeout(r, 10)).then(() => {
+      expect(document.title).toEqual(`xrpl_explorer | ledgers`)
+      expect(window.dataLayer).toEqual([
+        {
+          page_path: '/',
+          page_title: 'xrpl_explorer | ledgers',
+          event: 'screen_view',
+          network: 'mainnet',
+        },
+      ])
+    })
+  })
+
   it('renders custom mode homepage', async () => {
     process.env.VITE_ENVIRONMENT = 'custom'
     delete process.env.VITE_P2P_RIPPLED_HOST //  For custom as there is no p2p.


### PR DESCRIPTION
## High Level Overview of Change

coinmarketcap.com was linking to an old address that was an account page with no account supplied.

### Context of Change

Thank you @bugsbunnies for finding this.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
