### PR TITLE
feat: remove gravatar field

### DIFF
--- a/src/containers/Accounts/AccountHeader/test/actions.test.js
+++ b/src/containers/Accounts/AccountHeader/test/actions.test.js
@@ -41,7 +41,6 @@ describe('AccountHeader Actions', () => {
         emailHash: undefined,
         flags: [],
         balance: '123456000',
-        gravatar: undefined,
         nftMinter: undefined,
         previousTxn:
           '6B6F2CA1633A22247058E988372BA9EFFFC5BF10212230B67341CA32DC9D4A82',
@@ -85,7 +84,6 @@ describe('AccountHeader Actions', () => {
         emailHash: undefined,
         flags: [],
         balance: '1172875760329',
-        gravatar: undefined,
         previousTxn:
           '259A84CE4B3B09D5FBCAA133F62FC767CA2B57B3C64CF065F7546AA63D55E070',
         previousLedger: 67657581,
@@ -196,7 +194,6 @@ describe('AccountHeader Actions', () => {
         emailHash: undefined,
         flags: [],
         balance: '123456000',
-        gravatar: undefined,
         nftMinter: undefined,
         previousTxn:
           '6B6F2CA1633A22247058E988372BA9EFFFC5BF10212230B67341CA32DC9D4A82',

--- a/src/containers/Token/TokenHeader/index.tsx
+++ b/src/containers/Token/TokenHeader/index.tsx
@@ -34,7 +34,6 @@ interface TokenHeaderProps {
     obligations: string
     domain: string
     emailHash: string
-    gravatar: string
     previousLedger: number
     previousTxn: string
     flags: string[]
@@ -199,12 +198,17 @@ const TokenHeader = ({
     )
   }
 
-  const { gravatar } = data
+  const { emailHash } = data
   return (
     <div className="box token-header">
       <div className="section box-header">
         <Currency currency={currency} />
-        {gravatar && <img alt={`${currency} logo`} src={gravatar} />}
+        {emailHash && (
+          <img
+            alt={`${currency} logo`}
+            src={`https://www.gravatar.com/avatar/${emailHash.toLowerCase()}`}
+          />
+        )}
       </div>
       <div className="box-content">
         {loading ? <Loader /> : renderHeaderContent()}

--- a/src/containers/Token/TokenHeader/test/actions.test.js
+++ b/src/containers/Token/TokenHeader/test/actions.test.js
@@ -37,7 +37,6 @@ describe('TokenHeader Actions', () => {
       emailHash: undefined,
       flags: [],
       balance: '123456000',
-      gravatar: undefined,
       previousTxn:
         '6B6F2CA1633A22247058E988372BA9EFFFC5BF10212230B67341CA32DC9D4A82',
       previousLedger: 68990183,

--- a/src/containers/shared/Interfaces.tsx
+++ b/src/containers/shared/Interfaces.tsx
@@ -12,7 +12,6 @@ export interface AccountFormattedInfo {
   emailHash?: string
   flags?: string[]
   balance?: string
-  gravatar?: any
   previousTxn?: string
   previousLedger?: number
   nftMinter?: string


### PR DESCRIPTION
## High Level Overview of Change

The `gravatar` field on `account_info` is undocumented and we should not use it. Instead use EmailHash property.

Closes #761

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)