### PR TITLE
Add link to "XRPL Explorer on GitHub" in Footer

### DIFF
--- a/src/containers/Footer/index.jsx
+++ b/src/containers/Footer/index.jsx
@@ -50,10 +50,14 @@ const Footer = () => {
             How to Contribute
           </a>
           <a
-            href="https://github.com/ripple/xrpl-dev-portal"
+            href="https://github.com/ripple/explorer" className="footer-link">
+            XRPL Explorer on GitHub
+          </a>
+          <a
+            href="https://github.com/XRPLF/xrpl-dev-portal"
             className="footer-link"
           >
-            XRPL on GitHub
+            XRPL.org Docs on GitHub
           </a>
         </div>
       </div>

--- a/src/containers/Footer/index.jsx
+++ b/src/containers/Footer/index.jsx
@@ -49,8 +49,7 @@ const Footer = () => {
           <a href="https://xrpl.org/contribute.html" className="footer-link">
             How to Contribute
           </a>
-          <a
-            href="https://github.com/ripple/explorer" className="footer-link">
+          <a href="https://github.com/ripple/explorer" className="footer-link">
             XRPL Explorer on GitHub
           </a>
           <a

--- a/src/containers/Footer/test/Footer.test.tsx
+++ b/src/containers/Footer/test/Footer.test.tsx
@@ -20,7 +20,7 @@ describe('Footer component', () => {
     const wrapper = createWrapper()
     expect(wrapper.find('.logo').length).toEqual(1)
     expect(wrapper.find('.copyright').length).toEqual(1)
-    expect(wrapper.find('.footer-link').length).toEqual(11)
+    expect(wrapper.find('.footer-link').length).toEqual(12)
     expect(wrapper.find('.footer-section-header').length).toEqual(3)
 
     wrapper.unmount()


### PR DESCRIPTION
## High Level Overview of Change

This XRPL Explorer is open source, but it's not immediately obvious where to find the code.

### Context of Change

This is already linked at the top of the page, but I think it'll be easier to find if it's also at the bottom, in the footer.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Documentation Updates
