### PR TITLE
fix: update link to retrieve amendments versions

### DIFF
--- a/src/containers/shared/amendmentUtils.ts
+++ b/src/containers/shared/amendmentUtils.ts
@@ -71,7 +71,7 @@ export async function nameOfAmendmentID(id: string) {
 
 async function fetchMinRippledVersions() {
   const response = await axios.get(
-    'https://raw.githubusercontent.com/XRPLF/xrpl-dev-portal/master/content/concepts/consensus-network/amendments/known-amendments.md',
+    'https://raw.githubusercontent.com/XRPLF/xrpl-dev-portal/master/content/resources/known-amendments.md',
   )
   const text = response.data
   const mapping: any = {}


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->

The link we used to parse amendments versions has been now moved to:
https://raw.githubusercontent.com/XRPLF/xrpl-dev-portal/master/content/resources/known-amendments.md

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
