### PR TITLE
fix: show info for old transactions

### DIFF
--- a/src/rippled/lib/rippled.js
+++ b/src/rippled/lib/rippled.js
@@ -24,8 +24,7 @@ const formatPaychannel = (d) => ({
 })
 
 const executeQuery = async (rippledSocket, params) =>
-  // `clio` defaults the `api_version` to `2` and `rippled` to `1`.
-  rippledSocket.send({ api_version: 1, ...params }).catch((error) => {
+  rippledSocket.send(params).catch((error) => {
     const message =
       error.response && error.response.error_message
         ? error.response.error_message
@@ -170,6 +169,7 @@ const getTransaction = (rippledSocket, txHash) => {
 const getAccountInfo = (rippledSocket, account) =>
   query(rippledSocket, {
     command: 'account_info',
+    api_version: 1,
     account,
     ledger_index: 'validated',
     signer_lists: true,


### PR DESCRIPTION
## High Level Overview of Change

Viewing old transactions was broken by #835. When sending `api_version: 1` to clio it will currently forward to a rippled node which is not full history. That will be addresses soon but until then wont send now that for every request.

Explicitly send `api_version` when getting `account_info` because we only want the result from the most recently validated ledger.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)