### PR TITLE
fix: fix OfferCreate Simple/Table spacing

### DIFF
--- a/src/containers/Transactions/simpleTab.scss
+++ b/src/containers/Transactions/simpleTab.scss
@@ -48,6 +48,10 @@ $subdued-color: $black-40;
 
           .currency {
             display: block;
+          }
+
+          .currency,
+          .one-line {
             margin: -1px 0px -16px;
             color: $subdued-color;
             font-size: 11px;

--- a/src/containers/shared/components/Transaction/OfferCreate/TableDetail.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/TableDetail.tsx
@@ -14,7 +14,7 @@ export const TableDetail = (props: any) => {
         <span className="label">{t('price')}:</span>
 
         <span className="amount" data-test="amount">
-          {`${Number(price)}`}
+          {`${Number(price)} `}
           <Currency
             currency={firstCurrency.currency}
             issuer={firstCurrency.issuer}

--- a/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/test/OfferCreateTableDetail.test.tsx
@@ -11,7 +11,7 @@ describe('OfferCreate: TableDetail', () => {
     const wrapper = createWrapper(mockOfferCreateWithCancel)
 
     expect(wrapper.find('[data-test="pair"]')).toHaveText(
-      'price:612.518\uE900 XRP/CSC.rCSC',
+      'price:612.518 \uE900 XRP/CSC.rCSC',
     )
     expect(wrapper.find('[data-test="cancel-id"]')).toHaveText(
       'cancel_offer #44866443',
@@ -29,7 +29,7 @@ describe('OfferCreate: TableDetail', () => {
     const wrapper = createWrapper(mockOfferCreate)
 
     expect(wrapper.find('[data-test="pair"]')).toHaveText(
-      'price:0.00207696\uE900 XRP/BCH.rcyS',
+      'price:0.00207696 \uE900 XRP/BCH.rcyS',
     )
     expect(wrapper.find('[data-test="offer-id"]')).not.toExist()
     expect(wrapper.find('[data-test="amount-buy"]')).toHaveText(
@@ -44,7 +44,7 @@ describe('OfferCreate: TableDetail', () => {
     const wrapper = createWrapper(mockOfferCreateInvertedCurrencies)
 
     expect(wrapper.find('[data-test="pair"]')).toHaveText(
-      'price:0.346896\uE900 XRP/USD.rvYA',
+      'price:0.346896 \uE900 XRP/USD.rvYA',
     )
   })
 })

--- a/src/containers/shared/components/TransactionTable/styles.scss
+++ b/src/containers/shared/components/TransactionTable/styles.scss
@@ -122,10 +122,6 @@
       text-transform: none;
     }
 
-    .currency {
-      margin-left: 5px;
-    }
-
     span {
       display: inline-block;
       margin-right: 5px;


### PR DESCRIPTION
## High Level Overview of Change

The bottom margin in the Price row in Simple was too much, and there was extra spacing between the currency pair in the TableDetail. This PR fixes those issues.

### Context of Change

Follow up from #841 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

### Before
<img width="762" alt="image" src="https://github.com/ripple/explorer/assets/8029314/41727f1b-730e-49de-9c81-e3186b1bb298">
<img width="494" alt="image" src="https://github.com/ripple/explorer/assets/8029314/dbebdb45-7262-41a7-8097-bf0241d366fe">

### After
<img width="762" alt="image" src="https://github.com/ripple/explorer/assets/8029314/e51aa619-e742-4c82-a317-32e0499b37c0">
<img width="494" alt="image" src="https://github.com/ripple/explorer/assets/8029314/918989ff-e676-4618-b0c5-87d688a075f4">

## Test Plan

Works locally.