### PR TITLE
changed the href to fix the problem

### DIFF
--- a/src/containers/shared/components/DomainLink.tsx
+++ b/src/containers/shared/components/DomainLink.tsx
@@ -7,16 +7,19 @@ export interface Props {
   domain: string
 }
 
+// Matches a protocol (e.g. 'http://' or 'https://') at the start of a string.
+const protocolRegex = /^([a-z][a-z0-9+\-.]*):\/\//
+
 const DomainLink = (props: Props) => {
   const { className, decode = false, domain } = props
 
   // If decode is true, decode the domain
   const decodedDomain = decode ? decodeHex(domain) : domain
 
-  // Check if the decodedDomain contains a protocol (http:// or https://)
-  const domainHasProtocol = decodedDomain.match(/^([a-z][a-z0-9+\-.]*):\/\//)
+  // Use the test method to check for the protocol
+  const domainHasProtocol = protocolRegex.test(decodedDomain)
 
-  // if the decodedDomain already has a protocol, use it; oitherwise, add 'https://'
+  // If decoded domain does not have a protocol, add one ; otherwise, don't
   const href = domainHasProtocol ? decodedDomain : `https://${decodedDomain}`
 
   return (

--- a/src/containers/shared/components/DomainLink.tsx
+++ b/src/containers/shared/components/DomainLink.tsx
@@ -14,7 +14,7 @@ const DomainLink = (props: Props) => {
       className={classnames(`domain`, className)}
       rel="noopener noreferrer"
       target="_blank"
-      href={`https://${decode ? decodeHex(domain) : domain}`}
+      href={decode ? domain : `https://${domain}`}
     >
       {decode ? decodeHex(domain) : domain}
     </a>

--- a/src/containers/shared/components/DomainLink.tsx
+++ b/src/containers/shared/components/DomainLink.tsx
@@ -8,7 +8,7 @@ export interface Props {
 }
 
 // Matches a protocol (e.g. 'http://' or 'https://') at the start of a string.
-const protocolRegex = /^([a-z][a-z0-9+\-.]*):\/\//
+const PROTOCOL_REGEX = /^([a-z][a-z0-9+\-.]*):\/\//
 
 const DomainLink = (props: Props) => {
   const { className, decode = false, domain } = props
@@ -17,7 +17,7 @@ const DomainLink = (props: Props) => {
   const decodedDomain = decode ? decodeHex(domain) : domain
 
   // Use the test method to check for the protocol
-  const domainHasProtocol = protocolRegex.test(decodedDomain)
+  const domainHasProtocol = PROTOCOL_REGEX.test(decodedDomain)
 
   // If decoded domain does not have a protocol, add one ; otherwise, don't
   const href = domainHasProtocol ? decodedDomain : `https://${decodedDomain}`

--- a/src/containers/shared/components/DomainLink.tsx
+++ b/src/containers/shared/components/DomainLink.tsx
@@ -9,12 +9,27 @@ export interface Props {
 
 const DomainLink = (props: Props) => {
   const { className, decode = false, domain } = props
+
+  // Ensure that "https://" is not added twice
+  const domainWithoutProtocol = domain.replace(/^https?:\/\//, '')
+
+  // If decode is true, decode the domain
+  const decodedDomain = decode
+    ? decodeHex(domainWithoutProtocol)
+    : domainWithoutProtocol
+
+  // Construct the href based on the decoded or original domain
+  const href =
+    decodedDomain.startsWith('http://') || decodedDomain.startsWith('https://')
+      ? decodedDomain
+      : `https://${decodedDomain}`
+
   return (
     <a
-      className={classnames(`domain`, className)}
+      className={classnames('domain', className)}
       rel="noopener noreferrer"
       target="_blank"
-      href={decode ? domain : `https://${domain}`}
+      href={href}
     >
       {decode ? decodeHex(domain) : domain}
     </a>

--- a/src/containers/shared/components/DomainLink.tsx
+++ b/src/containers/shared/components/DomainLink.tsx
@@ -10,19 +10,14 @@ export interface Props {
 const DomainLink = (props: Props) => {
   const { className, decode = false, domain } = props
 
-  // Ensure that "https://" is not added twice
-  const domainWithoutProtocol = domain.replace(/^https?:\/\//, '')
-
   // If decode is true, decode the domain
-  const decodedDomain = decode
-    ? decodeHex(domainWithoutProtocol)
-    : domainWithoutProtocol
+  const decodedDomain = decode ? decodeHex(domain) : domain
 
-  // Construct the href based on the decoded or original domain
-  const href =
-    decodedDomain.startsWith('http://') || decodedDomain.startsWith('https://')
-      ? decodedDomain
-      : `https://${decodedDomain}`
+  // Check if the decodedDomain contains a protocol (http:// or https://)
+  const domainHasProtocol = decodedDomain.match(/^([a-z][a-z0-9+\-.]*):\/\//)
+
+  // if the decodedDomain already has a protocol, use it; oitherwise, add 'https://'
+  const href = domainHasProtocol ? decodedDomain : `https://${decodedDomain}`
 
   return (
     <a

--- a/src/containers/shared/components/test/DomainLink.test.tsx
+++ b/src/containers/shared/components/test/DomainLink.test.tsx
@@ -39,12 +39,12 @@ describe('DomainLink', () => {
     wrapper.unmount()
   })
   it('handles domain link with domain provided in HEX-encoded format', () => {
-    const wrapper = mount(
-      <DomainLink decode domain="68747470733A2F2F6578616D706C652E636F6D" />,
-    )
+    const url = 'https://example.com'
+    const urlInHex = '68747470733A2F2F6578616D706C652E636F6D'
+    const wrapper = mount(<DomainLink decode domain={urlInHex} />)
     expect(wrapper.find('a').props().className).toEqual('domain')
-    expect(wrapper.find('a').text()).toEqual('https://example.com')
-    expect(wrapper.find('a').props().href).toEqual('https://example.com')
+    expect(wrapper.find('a').text()).toEqual(url)
+    expect(wrapper.find('a').props().href).toEqual(url)
     wrapper.unmount()
   })
 })

--- a/src/containers/shared/components/test/DomainLink.test.tsx
+++ b/src/containers/shared/components/test/DomainLink.test.tsx
@@ -38,4 +38,13 @@ describe('DomainLink', () => {
     expect(wrapper.find('a').props().href).toEqual('https://sologenic.com')
     wrapper.unmount()
   })
+  it('handles domain link with domain provided in HEX-encoded format', () => {
+    const wrapper = mount(
+      <DomainLink decode domain="68747470733A2F2F6578616D706C652E636F6D" />,
+    )
+    expect(wrapper.find('a').props().className).toEqual('domain')
+    expect(wrapper.find('a').text()).toEqual('https://example.com')
+    expect(wrapper.find('a').props().href).toEqual('https://example.com')
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

Slightly changed the _href_ in the **DomainLink.tsx** file. Addresses issue #714 

### Context of Change
Some accounts such as the issuers of NFTs put fully formatted urls in the domain field. Since _"https://"_ is prepended to the value of that field, an invalid URI is created. The change adds _"https://"_ only if a protocol is not detected.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After
**Before:** _"https://"_ was prepended to the value of that field, creating a invalid URL
**After:** Now, _"https://"_ is added only if a protocol is not detected.
## Test Plan

No test plan in practice for the current change.
<!--
## Future Tasks
For future tasks related to PR.
-->

## Note
This is the example given in the issue: https://livenet.xrpl.org/accounts/r481fwr9G6GqJsnDTRanb9wicGjFf3rfgp/transactions

For some reason, whenever I click the **DOMAIN** on the accounts page(of the example), it leads to:
```
http://https//marketplace-api.onxrp.com/api/metadata/
```

When it should lead to this, instead:
```
https://marketplace-api.onxrp.com/api/metadata/
```

I suspect that there might be a problem with the data being passed to the **DomainLink** component. I have not been able to pinpoint it though.

Further feedback is much appreciated.

Thanks you :)
