### PR TITLE
fix: assorted prod performance fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,8 +34,8 @@
     }
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit"
   },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,

--- a/server/routes/v1/currentMetrics.js
+++ b/server/routes/v1/currentMetrics.js
@@ -7,7 +7,7 @@ module.exports = async (req, res) => {
     const metrics = await streams.getCurrentMetrics()
     return res.status(200).json(metrics)
   } catch (error) {
-    log.error(`Failed healthcheck w/ code ${error.code}: ${error.message}`)
+    log.error(`Failed metrics fetch w/ code ${error.code}: ${error.message}`)
     return res.status(error.code || 500).json({ message: error.message })
   }
 }

--- a/src/containers/shared/amendmentUtils.ts
+++ b/src/containers/shared/amendmentUtils.ts
@@ -50,8 +50,8 @@ async function fetchAmendmentNames() {
   return amendmentNames
 }
 
-function sha512Half(buffer: Uint8Array) {
-  return bytesToHex(sha512(buffer)).slice(0, 64)
+function sha512Half(bytes: Uint8Array) {
+  return bytesToHex(sha512(bytes)).slice(0, 64)
 }
 
 export async function nameOfAmendmentID(id: string) {

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -5,8 +5,8 @@ import Log from '../log'
 import SocketContext from '../SocketContext'
 import { getNegativeUNL, getQuorum } from '../../../rippled'
 import { getLedger, getServerInfo } from '../../../rippled/lib/rippled'
-import { EPOCH_OFFSET } from '../../../rippled/lib/utils'
 import { summarizeLedger } from '../../../rippled/lib/summarizeLedger'
+import { convertRippleDate } from '../../../rippled/lib/convertRippleDate'
 
 const MAX_LEDGER_COUNT = 20
 
@@ -187,7 +187,7 @@ class Streams extends Component {
     Log.info('new ledger', ledgerIndex)
     ledger.ledger_hash = ledgerHash
     ledger.txn_count = txnCount
-    ledger.close_time = (data.ledger_time + EPOCH_OFFSET) * 1000
+    ledger.close_time = convertRippleDate(data.ledger_time)
 
     const baseFee = data.fee_base / 1000000
     return {
@@ -242,7 +242,7 @@ class Streams extends Component {
         ledger_hash: ledgerHash,
         pubkey,
         partial: !data.full,
-        time: (data.signing_time + EPOCH_OFFSET) * 1000,
+        time: convertRippleDate(data.signing_time),
         cookie: data.cookie,
       }
     }

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -313,8 +313,6 @@ class Streams extends Component {
       }
 
       ledgers[ledgerIndex].hashes[ledgerHash].push({
-        ledger_index: ledgerIndex,
-        ledger_hash: ledgerHash,
         pubkey: data.pubkey,
         partial: data.partial,
         time: data.time,

--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -8,10 +8,10 @@ import { getLedger, getServerInfo } from '../../../rippled/lib/rippled'
 import { summarizeLedger } from '../../../rippled/lib/summarizeLedger'
 import { convertRippleDate } from '../../../rippled/lib/convertRippleDate'
 
-const MAX_LEDGER_COUNT = 20
+const MAX_LEDGER_COUNT = 15
 
 const PURGE_INTERVAL = 10 * 1000
-const MAX_AGE = 120 * 1000
+const MAX_AGE = 90 * 1000
 
 const throttle = (func, limit) => {
   let inThrottle

--- a/src/containers/shared/components/Transaction/OfferCreate/Description.tsx
+++ b/src/containers/shared/components/Transaction/OfferCreate/Description.tsx
@@ -3,7 +3,6 @@ import { localizeDate } from '../../../utils'
 import {
   DATE_OPTIONS,
   CURRENCY_ORDER,
-  RIPPLE_EPOCH,
   XRP_BASE,
   normalizeAmount,
 } from '../../../transactionUtils'
@@ -12,6 +11,7 @@ import {
   TransactionDescriptionComponent,
   TransactionDescriptionProps,
 } from '../types'
+import { convertRippleDate } from '../../../../../rippled/lib/utils'
 
 const normalize = (amount: any) => amount.value || amount / XRP_BASE
 
@@ -39,7 +39,7 @@ const Description: TransactionDescriptionComponent = (
   }
 
   const renderLine4 = () => {
-    const unixT = (data.tx.Expiration + RIPPLE_EPOCH) * 1000
+    const unixT = convertRippleDate(data.tx.Expiration)
     const today = new Date()
     const transString =
       unixT - today.getTime() > 0

--- a/src/containers/shared/components/Transaction/UNLModify/Simple.tsx
+++ b/src/containers/shared/components/Transaction/UNLModify/Simple.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { encodeNodePublic } from 'ripple-address-codec'
 
+import { hexToBytes } from '@xrplf/isomorphic/utils'
 import { SimpleRow } from '../SimpleRow'
 import { TransactionSimpleProps } from '../types'
 import { UNLModify } from './types'
@@ -11,7 +12,7 @@ export const Simple = ({ data }: TransactionSimpleProps<UNLModify>) => {
   const { t } = useTranslation()
   const tx = data.instructions
 
-  const encoded = encodeNodePublic(Buffer.from(tx.UNLModifyValidator, 'hex'))
+  const encoded = encodeNodePublic(hexToBytes(tx.UNLModifyValidator))
 
   return (
     <>

--- a/src/containers/shared/transactionUtils.ts
+++ b/src/containers/shared/transactionUtils.ts
@@ -8,7 +8,6 @@ import type {
 import { IssuedCurrencyAmount, Transaction } from './types'
 import { localizeNumber, CURRENCY_OPTIONS } from './utils'
 
-export const RIPPLE_EPOCH = 946684800
 export const SUCCESSFUL_TRANSACTION = 'tesSUCCESS'
 export const XRP_BASE = 1000000
 export const hexMatch = /^(0x)?[0-9A-Fa-f]+$/

--- a/src/index.html
+++ b/src/index.html
@@ -45,13 +45,6 @@
     You need to enable JavaScript to run this app.
   </noscript>
   <div class="xrpl-explorer" id="xrpl-explorer"></div>
-  <% if(DEV) { %>
-    <!-- Vite in development mode was not defining Buffer -->
-    <script type="module">
-      import { Buffer } from "buffer";
-      window.Buffer = Buffer;
-    </script>
-  <% } %>
   <script type="module" src="./index.tsx"></script>
   <!--
       This HTML file is a template.

--- a/src/rippled/NFTTransactions.ts
+++ b/src/rippled/NFTTransactions.ts
@@ -1,5 +1,6 @@
 import { XrplClient } from 'xrpl-client'
 import { encodeAccountID } from 'ripple-address-codec'
+import { hexToBytes } from '@xrplf/isomorphic/utils'
 import { getNFTTransactions as getNFTTxs } from './lib/rippled'
 import { formatTransaction } from './lib/utils'
 import summarize from './lib/txSummary'
@@ -56,5 +57,5 @@ export const parseIssuerFromNFTokenID = (
   if (issuerPortion.length < 20) {
     return undefined
   }
-  return encodeAccountID(Buffer.from(nftokenID.substring(8, 48), 'hex'))
+  return encodeAccountID(hexToBytes(nftokenID.substring(8, 48)))
 }

--- a/src/rippled/lib/convertRippleDate.ts
+++ b/src/rippled/lib/convertRippleDate.ts
@@ -1,4 +1,4 @@
 const MILLIS_PER_SECOND = 1000
-export const EPOCH_OFFSET = 946684800000
+const EPOCH_OFFSET = 946684800000
 export const convertRippleDate = (date: number) =>
   date * MILLIS_PER_SECOND + EPOCH_OFFSET

--- a/src/rippled/lib/txSummary/index.js
+++ b/src/rippled/lib/txSummary/index.js
@@ -7,23 +7,29 @@ const getInstructions = (tx, meta) => {
   return parser(tx, meta)
 }
 
-const summarizeTransaction = (d, details = false) => ({
-  hash: d.hash,
-  ctid: d.ctid,
-  type: d.tx.TransactionType,
-  result: d.meta.TransactionResult,
-  account: d.tx.Account,
-  index: Number(d.meta.TransactionIndex),
-  fee: d.tx.Fee / 1000000,
-  sequence: d.tx.Sequence,
-  ticketSequence: d.tx.TicketSequence,
-  isHook: !!d.tx.EmitDetails,
-  date: d.date,
-  details: details
-    ? {
-        instructions: getInstructions(d.tx, d.meta),
-      }
-    : undefined,
-})
+const summarizeTransaction = (d, details = false) => {
+  const summary = {
+    hash: d.hash,
+    ctid: d.ctid,
+    type: d.tx.TransactionType,
+    result: d.meta.TransactionResult,
+    account: d.tx.Account,
+  }
+  if (details === false) return summary
+  return {
+    ...summary,
+    index: Number(d.meta.TransactionIndex),
+    fee: d.tx.Fee / 1000000,
+    sequence: d.tx.Sequence,
+    ticketSequence: d.tx.TicketSequence,
+    isHook: !!d.tx.EmitDetails,
+    date: d.date,
+    details: details
+      ? {
+          instructions: getInstructions(d.tx, d.meta),
+        }
+      : undefined,
+  }
+}
 
 export default summarizeTransaction

--- a/src/rippled/lib/utils.js
+++ b/src/rippled/lib/utils.js
@@ -1,3 +1,4 @@
+import { hexToString } from '@xrplf/isomorphic/utils'
 import { convertRippleDate } from './convertRippleDate'
 import { formatSignerList } from './formatSignerList'
 import { decodeHex } from '../../containers/shared/transactionUtils'
@@ -63,7 +64,7 @@ const formatAccountInfo = (info, serverInfoValidated) => ({
     : undefined,
   tick: info.TickSize,
   rate: info.TransferRate ? (info.TransferRate - BILLION) / BILLION : undefined,
-  domain: info.Domain ? Buffer.from(info.Domain, 'hex').toString() : undefined,
+  domain: info.Domain ? hexToString(info.Domain) : undefined,
   emailHash: info.EmailHash,
   flags: buildFlags(info.Flags, ACCOUNT_FLAGS),
   balance: info.Balance,
@@ -104,7 +105,7 @@ function RippledError(message, code) {
 }
 
 function convertHexToString(hex, encoding = 'utf8') {
-  return hex ? Buffer.from(hex, 'hex').toString(encoding) : undefined
+  return hex ? hexToString(hex) : undefined
 }
 
 const formatNFTInfo = (info) => ({

--- a/src/rippled/lib/utils.js
+++ b/src/rippled/lib/utils.js
@@ -1,4 +1,4 @@
-import { convertRippleDate, EPOCH_OFFSET } from './convertRippleDate'
+import { convertRippleDate } from './convertRippleDate'
 import { formatSignerList } from './formatSignerList'
 import { decodeHex } from '../../containers/shared/transactionUtils'
 
@@ -133,5 +133,4 @@ export {
   formatAccountInfo,
   convertHexToString,
   formatNFTInfo,
-  EPOCH_OFFSET,
 }

--- a/src/rippled/nUNL.js
+++ b/src/rippled/nUNL.js
@@ -1,4 +1,5 @@
 import { encodeNodePublic } from 'ripple-address-codec'
+import { hexToBytes } from '@xrplf/isomorphic/utils'
 
 import { getNegativeUNL as getRippledNegativeUNL } from './lib/rippled'
 import logger from './lib/logger'
@@ -19,7 +20,7 @@ const getNegativeUNL = (rippledSocket) => {
       if (validators !== undefined) {
         return validators
           .map((obj) => obj.DisabledValidator.PublicKey)
-          .map((key) => encodeNodePublic(Buffer.from(key, 'hex')))
+          .map((key) => encodeNodePublic(hexToBytes(key)))
       }
 
       return []

--- a/vite.config.js
+++ b/vite.config.js
@@ -78,7 +78,6 @@ export default defineConfig({
     }),
     // use env vars
     EnvironmentPlugin('all'),
-    // activate buffer and process
     // use TS paths
     viteTsconfigPaths(),
   ],


### PR DESCRIPTION
## High Level Overview of Change

This PR has several fixes:
* Fixes some issues with Buffer still being used in the app (even though the polyfill is no longer there)
* Fixes some issues with time calculations on ledgers
* Shrinks the max ledger count from 20 to 15 to save memory
* Optimizes the ledger and validation store to save memory on the home page

### Context of Change

The recent high load on the ledger has been stretching the memory and performance limits of the Explorer.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

N/A

## Test Plan

Fixes work locally. The optimizations shrink the object sizes by 25-30%.
