### PR TITLE
Convert Validator's History tab dates to UTC with note

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -431,7 +431,7 @@
   "no_sell_offers": "No sell offers",
   "no_buy_offers": "No buy offers",
   "validator_history.chain": "Chain",
-  "validator_history.date": "Date",
+  "validator_history.date": "Date (UTC)",
   "validator_history.missed": "Missed",
   "validator_history.score": "Score",
   "seller": "Seller",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -522,6 +522,5 @@
   "note": "Note",
   "indicate_unl": "indicates a validator on an UNL",
   "transaction_tokens_involved": "<Currency/> and <Currency2/>",
-  "transaction_tokens_swapped": "<Currency/> for <Currency2/>",
-  "dates_in_utc": "Dates are shown in Coordinated Universal Time (UTC)."
+  "transaction_tokens_swapped": "<Currency/> for <Currency2/>"
 }

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -522,5 +522,6 @@
   "note": "Note",
   "indicate_unl": "indicates a validator on an UNL",
   "transaction_tokens_involved": "<Currency/> and <Currency2/>",
-  "transaction_tokens_swapped": "<Currency/> for <Currency2/>"
+  "transaction_tokens_swapped": "<Currency/> for <Currency2/>",
+  "dates_in_utc": "Dates are shown in Coordinated Universal Time (UTC)."
 }

--- a/public/locales/es-ES/translations.json
+++ b/public/locales/es-ES/translations.json
@@ -518,6 +518,5 @@
   "note": "Nota",
   "indicate_unl": "indica a un validador en una UNL",
   "transaction_tokens_involved": "<Currency/> y <Currency2/>",
-  "transaction_tokens_swapped": "<Currency/> por <Currency2/>",
-  "dates_in_utc": null
+  "transaction_tokens_swapped": "<Currency/> por <Currency2/>"
 }

--- a/public/locales/es-ES/translations.json
+++ b/public/locales/es-ES/translations.json
@@ -427,7 +427,7 @@
   "no_sell_offers": "Sin ofertas de venta",
   "no_buy_offers": "Sin ofertas de compra",
   "validator_history.chain": "Cadena",
-  "validator_history.date": "Fecha",
+  "validator_history.date": "Fecha (UTC)",
   "validator_history.missed": "Perdidos",
   "validator_history.score": "Puntuación",
   "seller": "Vendedor",

--- a/public/locales/es-ES/translations.json
+++ b/public/locales/es-ES/translations.json
@@ -518,5 +518,6 @@
   "note": "Nota",
   "indicate_unl": "indica a un validador en una UNL",
   "transaction_tokens_involved": "<Currency/> y <Currency2/>",
-  "transaction_tokens_swapped": "<Currency/> por <Currency2/>"
+  "transaction_tokens_swapped": "<Currency/> por <Currency2/>",
+  "dates_in_utc": null
 }

--- a/public/locales/fr-FR/translations.json
+++ b/public/locales/fr-FR/translations.json
@@ -519,5 +519,6 @@
   "note": null,
   "indicate_unl": null,
   "transaction_tokens_involved": null,
-  "transaction_tokens_swapped": null
+  "transaction_tokens_swapped": null,
+  "dates_in_utc": null
 }

--- a/public/locales/fr-FR/translations.json
+++ b/public/locales/fr-FR/translations.json
@@ -429,7 +429,7 @@
   "no_sell_offers": "Aucune offre de vente",
   "no_buy_offers": "Aucune offre d'achat",
   "validator_history.chain": "Chaîne",
-  "validator_history.date": "Date",
+  "validator_history.date": "Date (UTC)",
   "validator_history.missed": "Manqué",
   "validator_history.score": "Score",
   "seller": "Vendeur",

--- a/public/locales/fr-FR/translations.json
+++ b/public/locales/fr-FR/translations.json
@@ -519,6 +519,5 @@
   "note": null,
   "indicate_unl": null,
   "transaction_tokens_involved": null,
-  "transaction_tokens_swapped": null,
-  "dates_in_utc": null
+  "transaction_tokens_swapped": null
 }

--- a/public/locales/ja-JP/translations.json
+++ b/public/locales/ja-JP/translations.json
@@ -518,6 +518,5 @@
   "note": null,
   "indicate_unl": null,
   "transaction_tokens_involved": null,
-  "transaction_tokens_swapped": null,
-  "dates_in_utc": null
+  "transaction_tokens_swapped": null
 }

--- a/public/locales/ja-JP/translations.json
+++ b/public/locales/ja-JP/translations.json
@@ -518,5 +518,6 @@
   "note": null,
   "indicate_unl": null,
   "transaction_tokens_involved": null,
-  "transaction_tokens_swapped": null
+  "transaction_tokens_swapped": null,
+  "dates_in_utc": null
 }

--- a/public/locales/ja-JP/translations.json
+++ b/public/locales/ja-JP/translations.json
@@ -429,7 +429,7 @@
   "no_sell_offers": "売却オファーがありません",
   "no_buy_offers": "購入オファーがありません",
   "validator_history.chain": "チェーン",
-  "validator_history.date": "日付",
+  "validator_history.date": "日付 (UTC)",
   "validator_history.missed": "失敗",
   "validator_history.score": "スコア",
   "seller": "売却者",

--- a/public/locales/ko-KR/translations.json
+++ b/public/locales/ko-KR/translations.json
@@ -516,6 +516,5 @@
   "note": null,
   "indicate_unl": null,
   "transaction_tokens_involved": null,
-  "transaction_tokens_swapped": null,
-  "dates_in_utc": null
+  "transaction_tokens_swapped": null
 }

--- a/public/locales/ko-KR/translations.json
+++ b/public/locales/ko-KR/translations.json
@@ -516,5 +516,6 @@
   "note": null,
   "indicate_unl": null,
   "transaction_tokens_involved": null,
-  "transaction_tokens_swapped": null
+  "transaction_tokens_swapped": null,
+  "dates_in_utc": null
 }

--- a/public/locales/ko-KR/translations.json
+++ b/public/locales/ko-KR/translations.json
@@ -427,7 +427,7 @@
   "no_sell_offers": "판매 offers 없음",
   "no_buy_offers": "구매 offers 없음",
   "validator_history.chain": "체인",
-  "validator_history.date": "날짜",
+  "validator_history.date": "날짜 (UTC)",
   "validator_history.missed": "누락",
   "validator_history.score": "점수",
   "seller": "판매자",

--- a/src/containers/Validators/HistoryTab.tsx
+++ b/src/containers/Validators/HistoryTab.tsx
@@ -56,32 +56,29 @@ export const HistoryTab = ({ reports }: HistoryTabProps) => {
   const { t } = useTranslation()
 
   return (
-    <>
-      <div className="history-note">{t('dates_in_utc')}</div>
-      <table className="history-table basic">
-        <thead>
+    <table className="history-table basic">
+      <thead>
+        <tr>
+          <th className="col-date">{t('validator_history.date')}</th>
+          <th className="col-chain">{t('validator_history.chain')}</th>
+          <th className="col-score">{t('validator_history.score')}</th>
+          <th className="col-total">{t('total')}</th>
+          <th className="col-missed">{t('validator_history.missed')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {reports ? (
+          reports.map((report) => (
+            <ReportRow report={report} key={report.date} />
+          ))
+        ) : (
           <tr>
-            <th className="col-date">{t('validator_history.date')}</th>
-            <th className="col-chain">{t('validator_history.chain')}</th>
-            <th className="col-score">{t('validator_history.score')}</th>
-            <th className="col-total">{t('total')}</th>
-            <th className="col-missed">{t('validator_history.missed')}</th>
+            <td colSpan={5}>
+              <Loader />
+            </td>
           </tr>
-        </thead>
-        <tbody>
-          {reports ? (
-            reports.map((report) => (
-              <ReportRow report={report} key={report.date} />
-            ))
-          ) : (
-            <tr>
-              <td colSpan={5}>
-                <Loader />
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-    </>
+        )}
+      </tbody>
+    </table>
   )
 }

--- a/src/containers/Validators/HistoryTab.tsx
+++ b/src/containers/Validators/HistoryTab.tsx
@@ -5,15 +5,17 @@ import { useLanguage } from '../shared/hooks'
 import './historyTab.scss'
 import { ValidatorReport } from '../shared/vhsTypes'
 
+const DEFAULT_HISTORY_TIMEZONE = 'UTC'
+
 const ReportRow = ({ report }: { report: ValidatorReport }) => {
   const language = useLanguage()
-
   return (
     <tr key={report.date}>
       <td className="col-date">
         <div className="full-date">
           {localizeDate(new Date(report.date), language, {
             dateStyle: 'full',
+            timeZone: DEFAULT_HISTORY_TIMEZONE,
           })}
         </div>
         <div className="abbrev-date">
@@ -21,6 +23,7 @@ const ReportRow = ({ report }: { report: ValidatorReport }) => {
             year: 'numeric',
             month: 'numeric',
             day: 'numeric',
+            timeZone: DEFAULT_HISTORY_TIMEZONE,
           })}
         </div>
       </td>
@@ -53,29 +56,34 @@ export const HistoryTab = ({ reports }: HistoryTabProps) => {
   const { t } = useTranslation()
 
   return (
-    <table className="history-table basic">
-      <thead>
-        <tr>
-          <th className="col-date">{t('validator_history.date')}</th>
-          <th className="col-chain">{t('validator_history.chain')}</th>
-          <th className="col-score">{t('validator_history.score')}</th>
-          <th className="col-total">{t('total')}</th>
-          <th className="col-missed">{t('validator_history.missed')}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {reports ? (
-          reports.map((report) => (
-            <ReportRow report={report} key={report.date} />
-          ))
-        ) : (
+    <>
+      <div className="history-note">
+        { t('dates_in_utc')}
+      </div>
+      <table className="history-table basic">
+        <thead>
           <tr>
-            <td colSpan={5}>
-              <Loader />
-            </td>
+            <th className="col-date">{t('validator_history.date')}</th>
+            <th className="col-chain">{t('validator_history.chain')}</th>
+            <th className="col-score">{t('validator_history.score')}</th>
+            <th className="col-total">{t('total')}</th>
+            <th className="col-missed">{t('validator_history.missed')}</th>
           </tr>
-        )}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {reports ? (
+            reports.map((report) => (
+              <ReportRow report={report} key={report.date} />
+            ))
+          ) : (
+            <tr>
+              <td colSpan={5}>
+                <Loader />
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </>
   )
 }

--- a/src/containers/Validators/HistoryTab.tsx
+++ b/src/containers/Validators/HistoryTab.tsx
@@ -57,9 +57,7 @@ export const HistoryTab = ({ reports }: HistoryTabProps) => {
 
   return (
     <>
-      <div className="history-note">
-        {t('dates_in_utc')}
-      </div>
+      <div className="history-note">{t('dates_in_utc')}</div>
       <table className="history-table basic">
         <thead>
           <tr>

--- a/src/containers/Validators/HistoryTab.tsx
+++ b/src/containers/Validators/HistoryTab.tsx
@@ -58,7 +58,7 @@ export const HistoryTab = ({ reports }: HistoryTabProps) => {
   return (
     <>
       <div className="history-note">
-        { t('dates_in_utc')}
+        {t('dates_in_utc')}
       </div>
       <table className="history-table basic">
         <thead>

--- a/src/containers/Validators/historyTab.scss
+++ b/src/containers/Validators/historyTab.scss
@@ -92,14 +92,3 @@
     color: $orange-50;
   }
 }
-
-.history-note {
-  overflow: hidden;
-  color: $black-40;
-  font-size: 12px;
-  letter-spacing: 0px;
-  line-height: 20px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  @include medium;
-}

--- a/src/containers/Validators/historyTab.scss
+++ b/src/containers/Validators/historyTab.scss
@@ -92,3 +92,14 @@
     color: $orange-50;
   }
 }
+
+.history-note {
+  overflow: hidden;
+  color: $black-40;
+  font-size: 12px;
+  letter-spacing: 0px;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  @include medium;
+}


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->

Convert the date in History tab into UTC to ensure consistency for users in different timezones.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

Date column header will change to inform users:

![Screenshot 2024-01-24 at 11 40 49 AM](https://github.com/ripple/explorer/assets/71317875/29f61397-d5ec-4305-ae92-c277d27a9751)


