### PR TITLE
fix: fix LedgersPage tests

### DIFF
--- a/src/containers/Ledgers/test/LedgersPage.test.js
+++ b/src/containers/Ledgers/test/LedgersPage.test.js
@@ -14,7 +14,7 @@ import prevLedgerMessage from './mock/prevLedger.json'
 import ledgerMessage from './mock/ledger.json'
 import validationMessage from './mock/validation.json'
 import rippledResponses from './mock/rippled.json'
-import { QuickHarness } from '../../test/utils'
+import { QuickHarness, flushPromises } from '../../test/utils'
 import { SelectedValidatorProvider } from '../useSelectedValidator'
 
 function sleep(ms) {
@@ -164,6 +164,7 @@ describe('Ledgers Page container', () => {
     expect(wrapper.find('.ledger').length).toBe(1)
 
     server.send(validationMessage)
+    await flushPromises()
     wrapper.update()
     expect(wrapper.find('.validation').length).toBe(1)
 
@@ -254,6 +255,7 @@ describe('Ledgers Page container', () => {
       expect(wrapper.find('.ledger').length).toBe(1)
 
       server.send(validationMessage)
+      await flushPromises()
       wrapper.update()
       expect(wrapper.find('.validation').length).toBe(1)
 


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes the `LedgersPage` tests so they stop failing intermittently/in some PRs (like #945).

### Context of Change

The `LedgersPage` tests fail for me locally.
![image](https://github.com/ripple/explorer/assets/8029314/f125f0b4-fa3d-4ca9-884f-a3d79637779e)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### TypeScript/Hooks Update

N/A - too complicated, not worth doing here.

## Test Plan

Tests pass locally now.
