### PR TITLE
fix: Upgrade Status renders on data error

### DIFF
--- a/src/containers/Network/UpgradeStatus.tsx
+++ b/src/containers/Network/UpgradeStatus.tsx
@@ -22,6 +22,7 @@ import {
 } from '../shared/vhsTypes'
 import NetworkContext from '../shared/NetworkContext'
 import { ledgerCompare } from './Nodes'
+import { Loader } from '../shared/components/Loader'
 
 interface DataAggregation {
   label: string
@@ -154,11 +155,15 @@ export const UpgradeStatus = () => {
           newValidatorList[validator.signing_key] = validator
         })
 
-        setVList(newValidatorList)
-        setUnlCount(
-          validators.filter((validator) => Boolean(validator.unl)).length,
-        )
-        return Object.values(newValidatorList)
+        if (validators != null) {
+          setVList(newValidatorList)
+          setUnlCount(
+            validators.filter((validator) => Boolean(validator.unl)).length,
+          )
+          return Object.values(newValidatorList)
+        }
+
+        return null
       })
       .catch((e) => Log.error(e))
 
@@ -192,7 +197,9 @@ export const UpgradeStatus = () => {
       })
       .catch((e) => Log.error(e))
     Promise.all([validatorsReq, nodesReq]).then(([validators, nodes]) => {
-      setAggregated(aggregateData(validators, nodes))
+      if (validators != null && nodes != null) {
+        setAggregated(aggregateData(validators, nodes))
+      }
     })
   }
 
@@ -250,9 +257,13 @@ export const UpgradeStatus = () => {
       </div>
       <div className="wrap">
         <NetworkTabs selected="upgrade-status" />
-        <div className="upgrade_status">
-          <BarChartVersion data={aggregated} stableVersion={stableVersion} />
-        </div>
+        {aggregated ? (
+          <div className="upgrade_status">
+            <BarChartVersion data={aggregated} stableVersion={stableVersion} />
+          </div>
+        ) : (
+          <Loader />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->

The VHS is experiencing an intermittent issue with CORS header that causes occasional disruption in data fetching for the Upgrade Status chart. This PR will add checks so to ensure the chart renders even when there's a disruption.  

<img width="1725" alt="Screenshot 2024-06-12 at 4 13 54 PM" src="https://github.com/ripple/explorer/assets/71317875/f5120024-4954-4d26-8c77-5ede6326d265">


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release
