### PR TITLE
Add metadata styling for Multi Purpose Token

### DIFF
--- a/src/containers/MPT/MPTHeader/Details.tsx
+++ b/src/containers/MPT/MPTHeader/Details.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import './styles.scss'
 import { useLanguage } from '../../shared/hooks'
-import { localizeNumber } from '../../shared/utils'
+import { isValidJsonString, localizeNumber } from '../../shared/utils'
 import { MPTIssuanceFormattedInfo } from '../../shared/Interfaces'
 import { TokenTableRow } from '../../shared/components/TokenTableRow'
+import { JsonView } from '../../shared/components/JsonView'
 
 interface Props {
   data: MPTIssuanceFormattedInfo
@@ -41,7 +42,18 @@ export const Details = ({ data }: Props) => {
         )}
         <TokenTableRow label={t('transfer_fee')} value={formattedFee ?? '0%'} />
         <TokenTableRow label={t('sequence_number_short')} value={sequence} />
-        {metadata && <TokenTableRow label={t('metadata')} value={metadata} />}
+        {metadata && (
+          <TokenTableRow
+            label={t('metadata')}
+            value={
+              isValidJsonString(metadata) ? (
+                <JsonView data={JSON.parse(metadata)} />
+              ) : (
+                metadata
+              )
+            }
+          />
+        )}
       </tbody>
     </table>
   )

--- a/src/containers/MPT/MPTHeader/styles.scss
+++ b/src/containers/MPT/MPTHeader/styles.scss
@@ -17,6 +17,10 @@
       @include for-size(desktop-up) {
         width: 490px;
       }
+
+      .jv-indent {
+        border-left: none;
+      }
     }
 
     .settings {

--- a/src/containers/shared/components/Transaction/MPTokenIssuanceCreate/Simple.tsx
+++ b/src/containers/shared/components/Transaction/MPTokenIssuanceCreate/Simple.tsx
@@ -3,8 +3,10 @@ import { SimpleRow } from '../SimpleRow'
 import { TransactionSimpleComponent, TransactionSimpleProps } from '../types'
 import { MPTokenIssuanceCreateInstructions } from './types'
 import { useLanguage } from '../../../hooks'
-import { localizeNumber } from '../../../utils'
+import { isValidJsonString, localizeNumber } from '../../../utils'
 import { MPTokenLink } from '../../MPTokenLink'
+import { JsonView } from '../../JsonView'
+import './styles.scss'
 
 export const Simple: TransactionSimpleComponent = ({
   data,
@@ -55,7 +57,11 @@ export const Simple: TransactionSimpleComponent = ({
           className="dt"
           data-test="mpt-metadata"
         >
-          {metadata}
+          {isValidJsonString(metadata) ? (
+            <JsonView data={JSON.parse(metadata)} />
+          ) : (
+            metadata
+          )}
         </SimpleRow>
       )}
     </>

--- a/src/containers/shared/components/Transaction/MPTokenIssuanceCreate/styles.scss
+++ b/src/containers/shared/components/Transaction/MPTokenIssuanceCreate/styles.scss
@@ -1,0 +1,3 @@
+.jv-indent {
+  border-left: none;
+}

--- a/src/containers/shared/utils.js
+++ b/src/containers/shared/utils.js
@@ -129,6 +129,15 @@ export const isEarlierVersion = (source, target) => {
   return false
 }
 
+export const isValidJsonString = (str) => {
+  try {
+    JSON.parse(str)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 // Document: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat
 export const localizeNumber = (
   num,


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->

MPTokenMetadata is an essential part of a MPT token as it allows issuers to define their own metadata standards, tailored to their specific requirements, encompassing details like asset codes, common names, symbols, or even visual representations.

This PR formats the display of this metadata field in the Explorer by adding json formatter for readability.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->
Spec: https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0033d-multi-purpose-tokens

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

MPTokenIssuanceCreate Page:

![Screenshot 2024-10-10 at 3 53 01 PM](https://github.com/user-attachments/assets/eb0b6f27-3d8e-494a-9af0-00f96f119d3e)

MPT Page:
![Screenshot 2024-10-10 at 3 53 20 PM](https://github.com/user-attachments/assets/5316a92f-4c22-4dcf-82cd-3dd6f6a6f3f8)
