### PR TITLE
fix: avoid initializing multiple connections

### DIFF
--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -7,13 +7,14 @@ const RIPPLEDS = []
 process.env.VITE_RIPPLED_HOST?.split(',').forEach((host) => {
   if (host?.includes(':')) {
     RIPPLEDS.push(`wss://${host}`)
-  } else {
+  } else if (process.env.VITE_RIPPLED_WS_PORT) {
     RIPPLEDS.push(`wss://${host}:${process.env.VITE_RIPPLED_WS_PORT}`)
-    if (!['', '443', undefined].includes(process.env.VITE_RIPPLED_WS_PORT)) {
-      RIPPLEDS.push(`wss://${host}:443`)
-    }
+  } else {
+    RIPPLEDS.push(`wss://${host}`)
   }
 })
+
+console.log(RIPPLEDS)
 
 const RIPPLED_CLIENT = new XrplClient(RIPPLEDS, { tryAllNodes: true })
 // If there is a separate peer to peer server for admin requests, use it. Otherwise use the default url for everything.

--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -14,8 +14,6 @@ process.env.VITE_RIPPLED_HOST?.split(',').forEach((host) => {
   }
 })
 
-console.log(RIPPLEDS)
-
 const RIPPLED_CLIENT = new XrplClient(RIPPLEDS, { tryAllNodes: true })
 // If there is a separate peer to peer server for admin requests, use it. Otherwise use the default url for everything.
 const HAS_P2P_SOCKET =

--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -4,12 +4,15 @@ const utils = require('./utils')
 const streams = require('./streams')
 
 const RIPPLEDS = []
-process.env.VITE_RIPPLED_HOST?.split(',').forEach((d) => {
-  const rippled = d.split(':')
-  RIPPLEDS.push(
-    `wss://${rippled[0]}:${rippled[1] || process.env.VITE_RIPPLED_WS_PORT}`,
-    `wss://${rippled[0]}`,
-  )
+process.env.VITE_RIPPLED_HOST?.split(',').forEach((host) => {
+  if (host?.includes(':')) {
+    RIPPLEDS.push(`wss://${host}`)
+  } else {
+    RIPPLEDS.push(`wss://${host}:${process.env.VITE_RIPPLED_WS_PORT}`)
+    if (!['', '443', undefined].includes(process.env.VITE_RIPPLED_WS_PORT)) {
+      RIPPLEDS.push(`wss://${host}:443`)
+    }
+  }
 })
 
 const RIPPLED_CLIENT = new XrplClient(RIPPLEDS, { tryAllNodes: true })

--- a/server/routes/v1/tokens.js
+++ b/server/routes/v1/tokens.js
@@ -41,12 +41,15 @@ async function fetchXRPLMetaTokens(offset) {
       },
     )
     .then((resp) => resp.data)
-    .catch((e) => log.error(e))
+    .catch((e) => {
+      log.error(e)
+      return { count: 0 }
+    })
 }
 
 async function cacheXRPLMetaTokens() {
   let offset = 0
-  let tokensDataBatch = []
+  let tokensDataBatch = {}
   const allTokensFetched = []
 
   tokensDataBatch = await fetchXRPLMetaTokens(0)

--- a/src/containers/shared/SocketContext.tsx
+++ b/src/containers/shared/SocketContext.tsx
@@ -29,11 +29,13 @@ function getSocket(rippledUrl?: string): ExplorerXrplClient {
 
     if (host?.includes(':')) {
       wsUrls.push(`${prefix}://${host}`)
-    } else {
+    } else if (process.env.VITE_RIPPLED_WS_PORT) {
       wsUrls.push(`${prefix}://${host}:${process.env.VITE_RIPPLED_WS_PORT}`)
-      if (!['', '443', undefined].includes(process.env.VITE_RIPPLED_WS_PORT)) {
-        wsUrls.push(`${prefix}://${host}:443`)
+      if (process.env.VITE_ENVIRONMENT === 'custom') {
+        wsUrls.push(`${prefix}://${host}`)
       }
+    } else {
+      wsUrls.push(`${prefix}://${host}`)
     }
   })
 

--- a/src/containers/shared/SocketContext.tsx
+++ b/src/containers/shared/SocketContext.tsx
@@ -30,10 +30,10 @@ function getSocket(rippledUrl?: string): ExplorerXrplClient {
     if (host?.includes(':')) {
       wsUrls.push(`${prefix}://${host}`)
     } else {
-      wsUrls.push.apply(wsUrls, [
-        `${prefix}://${host}:${process.env.VITE_RIPPLED_WS_PORT}`,
-        `${prefix}://${host}:443`,
-      ])
+      wsUrls.push(`${prefix}://${host}:${process.env.VITE_RIPPLED_WS_PORT}`)
+      if (!['', '443', undefined].includes(process.env.VITE_RIPPLED_WS_PORT)) {
+        wsUrls.push(`${prefix}://${host}:443`)
+      }
     }
   })
 

--- a/src/containers/shared/test/SocketContext.test.ts
+++ b/src/containers/shared/test/SocketContext.test.ts
@@ -28,7 +28,7 @@ describe('getSocket', () => {
       const client = getSocket()
       expect(XrplClient).toHaveBeenNthCalledWith(
         1,
-        ['wss://somewhere.com:51233', 'wss://somewhere.com:443'],
+        ['wss://somewhere.com:51233'],
         {
           tryAllNodes: true,
         },
@@ -47,12 +47,7 @@ describe('getSocket', () => {
       const client = getSocket()
       expect(XrplClient).toHaveBeenNthCalledWith(
         1,
-        [
-          'wss://somewhere.com:51233',
-          'wss://somewhere.com:443',
-          'wss://elsewhere.com:51233',
-          'wss://elsewhere.com:443',
-        ],
+        ['wss://somewhere.com:51233', 'wss://elsewhere.com:51233'],
         {
           tryAllNodes: true,
         },
@@ -71,7 +66,7 @@ describe('getSocket', () => {
       const client = getSocket()
       expect(XrplClient).toHaveBeenNthCalledWith(
         1,
-        ['ws://somewhere.com:51233', 'ws://somewhere.com:443'],
+        ['ws://somewhere.com:51233'],
         {
           tryAllNodes: true,
         },
@@ -120,13 +115,9 @@ describe('getSocket', () => {
 
     it('should use ws when supplied entry is for a localhost', () => {
       const client = getSocket('localhost')
-      expect(XrplClient).toHaveBeenNthCalledWith(
-        1,
-        ['ws://localhost:51233', 'ws://localhost:443'],
-        {
-          tryAllNodes: true,
-        },
-      )
+      expect(XrplClient).toHaveBeenNthCalledWith(1, ['ws://localhost:51233'], {
+        tryAllNodes: true,
+      })
 
       expect((client as any).p2pSocket).not.toBeDefined()
     })


### PR DESCRIPTION
## High Level Overview of Change

Title says it all. There are multiple connections made to a node in the current implementation, at different ports (which all forward to the same place on livenet). While the connection isn't sustained, it still has to be made and canceled.

### Context of Change

There is a lot of load on s2 right now, so saving a connection or two might make a difference.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### TypeScript/Hooks Update

N/A

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Tested locally.
