### PR TITLE
fix double issuer address logic

### DIFF
--- a/src/containers/shared/components/TokenSearchResults/TokenSearchRow.tsx
+++ b/src/containers/shared/components/TokenSearchResults/TokenSearchRow.tsx
@@ -41,10 +41,10 @@ const IssuerAddress: FC<{ token: any; onClick: any }> = ({ token, onClick }) =>
       className="issuer-link"
     >
       <div className="issuer-name">
-        {token.meta.issuer.name ? `${token.meta.issuer.name} (` : token.issuer}
+        {token.meta.issuer.name && `${token.meta.issuer.name} (`}
       </div>
       <div className="issuer-address truncate">{token.issuer}</div>
-      <div>)</div>
+      {token.meta.issuer.name && <div>)</div>}
     </Link>
   ) : null
 


### PR DESCRIPTION
## High Level Overview of Change

Bug in the conditional rendering logic for issuer address, it accidentally double printed the issuer if a name was not provided in the data. Now only prints the issuer once with no parenthesis if a name is not provided.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

### TypeScript/Hooks Update

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript.
If this is not possible (e.g. it's too many changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
