### PR TITLE
feat: add % upgraded to the bar charts

### DIFF
--- a/src/containers/Network/BarChartVersion.tsx
+++ b/src/containers/Network/BarChartVersion.tsx
@@ -47,17 +47,21 @@ const CustomTooltip = ({
 }: TooltipProps<ValueType, NameType>) => {
   const { t } = useTranslation()
   if (active) {
+    const valCount = payload?.[0]?.payload?.validatorCount ?? 0
+    const valPercent = payload?.[0]?.payload?.validatorPercent.toFixed(2) ?? 0
+    const nodeCount = payload?.[0]?.payload?.nodeCount ?? 0
+    const nodePercent = payload?.[0]?.payload?.nodePercent.toFixed(2) ?? 0
     return (
       <div className="custom-tooltip">
         <p className="label">{t('version_display', { version: label })}</p>
         <p className="value">
           {t('validator_count', {
-            val_count: payload?.[0]?.payload?.validatorCount ?? 0,
+            val_count: `${valCount} (${valPercent}%)`,
           })}
         </p>
         <p className="value">
           {t('node_count', {
-            node_count: payload?.[0]?.payload?.nodeCount ?? 0,
+            node_count: `${nodeCount} (${nodePercent}%)`,
           })}
         </p>
       </div>


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

I was finding myself doing the percent upgraded calculation myself, and it would be easier if the website did the math for me, since it already has the numbers.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### TypeScript/Hooks Update

N/A

## Before / After

### Before
![image](https://github.com/user-attachments/assets/86245500-2cf4-46a2-853d-f2f765cb3f27)

### After
![image](https://github.com/user-attachments/assets/de140c8d-fd26-4082-9e7f-8fa9aaae011c)

## Test Plan

Works locally.
