### PR TITLE
fix: dedupe validations count using `pubkey`

### DIFF
--- a/src/containers/shared/components/Streams.jsx
+++ b/src/containers/shared/components/Streams.jsx
@@ -83,9 +83,16 @@ const formatLedgers = (data) =>
           return a.time - b.time
         })
 
+        // Dedupe validations count using pubkey
+        const rawUnlEntries = h[1].filter(
+          (entry) => typeof entry.unl === 'string' && entry.unl.length > 0,
+        )
+        const pubkeyList = rawUnlEntries.map((entry) => entry.pubkey)
+        const dedupedTrustedCount = new Set(pubkeyList).size
+
         return {
           hash: h[0],
-          trusted_count: h[1].filter((d) => d.unl).length,
+          trusted_count: dedupedTrustedCount,
           validations: h[1],
           unselected: !validated && Boolean(ledger.ledger_hash),
           validated,


### PR DESCRIPTION
## High Level Overview of Change

Validations count has been reported to show incorrect numerator value - [issue](https://github.com/ripple/explorer/issues/1142)

This fix adds logic to dedupe the validations count using unique `pubkey`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

### Codebase Modernization

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript,
and update tests to use the React Testing Library instead of Enzyme. If this is not possible (e.g. it's too many
changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript
- [ ] Updated tests to React Testing Library

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
