### PR TITLE
Use drops to represent txn-fees and reserves

### DIFF
--- a/src/containers/Validators/VotingTab.tsx
+++ b/src/containers/Validators/VotingTab.tsx
@@ -12,7 +12,6 @@ import {
   renderXRP,
 } from '../shared/utils'
 import { useAnalytics } from '../shared/analytics'
-import { XRP_BASE } from '../shared/transactionUtils'
 
 import './votingTab.scss'
 import { RouteLink } from '../shared/routing'
@@ -89,15 +88,15 @@ export const VotingTab: FC<{
       <div className="metrics metrics-voting">
         <div className="cell">
           <div className="label">{t('base_fee')}</div>
-          <div>{renderXRP(validatorData.base_fee / XRP_BASE)}</div>
+          <div>{renderXRP(validatorData.base_fee)} drops</div>
         </div>
         <div className="cell">
           <div className="label">{t('account_reserve')}</div>
-          <div>{renderXRP(validatorData.reserve_base / XRP_BASE)}</div>
+          <div>{renderXRP(validatorData.reserve_base)} drops</div>
         </div>
         <div className="cell">
           <div className="label">{t('object_reserve')}</div>
-          <div>{renderXRP(validatorData.reserve_inc / XRP_BASE)}</div>
+          <div>{renderXRP(validatorData.reserve_inc)} drops</div>
         </div>
       </div>
       <div className="amendment-label">{t('amendments')}</div>

--- a/src/containers/Validators/test/VotingTab.test.tsx
+++ b/src/containers/Validators/test/VotingTab.test.tsx
@@ -64,9 +64,15 @@ describe('VotingTab container', () => {
 
       // Render fees voting correctly
       expect(wrapper.find('.metrics .cell').length).toBe(3)
-      expect(wrapper.find('.metrics .cell').at(0).html()).toContain('0.00001')
-      expect(wrapper.find('.metrics .cell').at(1).html()).toContain('10.00')
-      expect(wrapper.find('.metrics .cell').at(2).html()).toContain('2.00')
+      expect(wrapper.find('.metrics .cell').at(0).html()).toContain(
+        '10.00 drops',
+      )
+      expect(wrapper.find('.metrics .cell').at(1).html()).toContain(
+        '10,000,000.00 drops',
+      )
+      expect(wrapper.find('.metrics .cell').at(2).html()).toContain(
+        '2,000,000.00 drops',
+      )
 
       // Render amendments correctly
       expect(wrapper.find('.amendment-label').length).toBe(1)


### PR DESCRIPTION
## High Level Overview of Change
This PR changes the unit-of-representation to drops, instead of 1 XRP. Certain quantities (like fees, account-reserve and object reserve) are very minute. For the purposes of readability, it is better represented as drops. 
(For reference: 1 XRP = 10 ^ 6 drops)

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

### Codebase Modernization

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript,
and update tests to use the React Testing Library instead of Enzyme. If this is not possible (e.g. it's too many
changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript
- [ ] Updated tests to React Testing Library

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->
At the present moment, the validator voting tab looks like this:

<img width="1895" height="776" alt="image" src="https://github.com/user-attachments/assets/e871bf1f-ca03-4cc2-bf61-0826c93c8899" />



This PR enables the voting tab to look like this:
<img width="1901" height="806" alt="image" src="https://github.com/user-attachments/assets/76eebeda-eb85-4cdb-bb6d-3ee37274cfcc" />


## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
