### PR TITLE
Explorer server: Add logs when receiving ledgerClosed messages and log rippled client state every 60 seconds

### DIFF
--- a/server/lib/rippled.js
+++ b/server/lib/rippled.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const { XrplClient } = require('xrpl-client')
+const log = require('./logger')({ name: 'rippled' })
 const utils = require('./utils')
 const streams = require('./streams')
 
@@ -31,10 +32,17 @@ const P2P_URL_BASE = process.env.VITE_P2P_RIPPLED_HOST
 const URL_HEALTH = `https://${P2P_URL_BASE}:${process.env.VITE_RIPPLED_PEER_PORT}/health`
 
 RIPPLED_CLIENT.on('ledger', (data) => {
+  log.info(`Received ${data?.type} message`)
   if (data.type === 'ledgerClosed') {
     streams.handleLedger(data)
   }
 })
+
+setInterval(() => {
+  log.info('Rippled client:', {
+    state: RIPPLED_CLIENT.getState?.() || 'unknown',
+  })
+}, 60_000) // Log rippled client state every 60 seconds
 
 const executeQuery = async (rippledSocket, params) =>
   rippledSocket.send(params).catch((error) => {


### PR DESCRIPTION
## High Level Overview of Change
Two changes
1. Log a message each time a ledgerClosed message is received.
2. Every 60 seconds, log the current state of the rippled client created via [xrpl-client](https://github.com/XRPL-Labs/xrpl-client).

### Context of Change
Although rare, we’ve observed that the Explorer server stops processing new ledger data—specifically, [this log line](https://github.com/ripple/explorer/blob/staging/server/lib/streams.js#L119) is not printed. As a result, the [metrics API endpoint](https://github.com/ripple/explorer/blob/staging/server/routes/v1/index.js#L12) begins serving stale data. The root cause is currently unclear; it could be due to a dropped WebSocket connection to the Clio host or the Clio host not sending any `ledgerClosed` messages. Importantly, during the incident, the Explorer backend remains up and responsive, continuing to serve API requests such as /health and /metrics ([code reference](https://github.com/ripple/explorer/blob/staging/server/routes/v1/index.js#L11-L12)).

The new logs will help us confirm the root cause if either of the above suspicions is correct, or rule them out if not.


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

### Codebase Modernization

<!--
In an effort to modernize the codebase, you should convert the files that you work with to React Hooks and TypeScript,
and update tests to use the React Testing Library instead of Enzyme. If this is not possible (e.g. it's too many
changes, touching too many files, etc.) please explain why here.
-->

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript
- [ ] Updated tests to React Testing Library

## Before / After
N/A

## Test Plan
Manually test the changes by running `npm run build && npm start` and confirm that logs are printed as expected. An example of state log is
```
[2025-08-27T19:32:33.456Z]  INFO: rippled/12345 on MacBook:
    Rippled client: {
      state: {
        online: true,
        latencyMs: { last: 80, avg: 81.3, secAgo: 2.181999921798706 },
        server: {
          version: '',
          uptime: 1294403,
          publicKey: '',
          networkId: 0,
          uri: 'wss://s2.ripple.com:51233'
        },
        ledger: { last: 98451664, validated: '32570-98451664', count: 98419094 },
        fee: { last: 12, avg: 12, secAgo: 2.181999921798706 },
        reserve: { base: 1, owner: 0.2 },
        secLastContact: 1.8569998741149902
      }
    }
```
