### PR TITLE
fix: convert CredentialCreate Expiration to readable date format

### DIFF
--- a/src/containers/shared/components/Transaction/CredentialCreate/Simple.tsx
+++ b/src/containers/shared/components/Transaction/CredentialCreate/Simple.tsx
@@ -5,10 +5,7 @@ import { SimpleRow } from '../SimpleRow'
 import { convertHexToString } from '../../../../../rippled/lib/utils'
 import { localizeDate } from '../../../utils'
 import { useLanguage } from '../../../hooks'
-import {
-  convertRippleDate,
-  MILLIS_PER_SECOND,
-} from '../../../../../rippled/lib/convertRippleDate'
+import { convertRippleDate } from '../../../../../rippled/lib/convertRippleDate'
 import { DATE_OPTIONS } from '../../../transactionUtils'
 
 const Simple: TransactionSimpleComponent = (
@@ -37,7 +34,7 @@ const Simple: TransactionSimpleComponent = (
       {expiration && (
         <SimpleRow label={t('expiration')} data-testid="expiration">
           {localizeDate(
-            new Date(convertRippleDate(expiration) * MILLIS_PER_SECOND),
+            new Date(convertRippleDate(expiration)),
             language,
             DATE_OPTIONS,
           )}

--- a/src/containers/shared/components/Transaction/CredentialCreate/test/CredentialCreateSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/CredentialCreate/test/CredentialCreateSimple.test.tsx
@@ -13,11 +13,7 @@ describe('CredentialCreate: Simple', () => {
       'rDeEwcsbGz4GXyGpyRuQo9vRGGT269Jmjk',
     )
     expectSimpleRowText(wrapper, 'credential-type', 'VerifiedAccount')
-    expectSimpleRowText(
-      wrapper,
-      'expiration',
-      'October 5, 2026 at 1:53:30 PM',
-    )
+    expectSimpleRowText(wrapper, 'expiration', 'October 5, 2026 at 1:53:30 PM')
 
     wrapper.unmount()
   })

--- a/src/containers/shared/components/Transaction/CredentialCreate/test/CredentialCreateSimple.test.tsx
+++ b/src/containers/shared/components/Transaction/CredentialCreate/test/CredentialCreateSimple.test.tsx
@@ -10,9 +10,14 @@ describe('CredentialCreate: Simple', () => {
     expectSimpleRowText(
       wrapper,
       'subject',
-      'rwXChshgJHh6KwwXY8hN1iNAiuyzJkz7p6',
+      'rDeEwcsbGz4GXyGpyRuQo9vRGGT269Jmjk',
     )
-    expectSimpleRowText(wrapper, 'credential-type', 'My test credential')
+    expectSimpleRowText(wrapper, 'credential-type', 'VerifiedAccount')
+    expectSimpleRowText(
+      wrapper,
+      'expiration',
+      'October 5, 2026 at 1:53:30 PM',
+    )
 
     wrapper.unmount()
   })

--- a/src/containers/shared/components/Transaction/CredentialCreate/test/CredentialCreateTableDetail.test.tsx
+++ b/src/containers/shared/components/Transaction/CredentialCreate/test/CredentialCreateTableDetail.test.tsx
@@ -9,12 +9,14 @@ describe('CredentialAcceptTableDetail ', () => {
     const wrapper = createWrapper(mockCredentialCreate)
 
     expect(wrapper.find('[data-testid="subject"]')).toHaveText(
-      'subject: rwXChshgJHh6KwwXY8hN1iNAiuyzJkz7p6',
+      'subject: rDeEwcsbGz4GXyGpyRuQo9vRGGT269Jmjk',
     )
     expect(wrapper.find('[data-testid="credential-type"]')).toHaveText(
-      'credential_type: My test credential',
+      'credential_type: VerifiedAccount',
     )
-    expect(wrapper.find('[data-testid="uri"]')).toHaveText('uri: testURI')
+    expect(wrapper.find('[data-testid="expiration"]')).toHaveText(
+      'expiration: 844523610',
+    )
 
     wrapper.unmount()
   })

--- a/src/containers/shared/components/Transaction/CredentialCreate/test/mock_data/CredentialCreate.json
+++ b/src/containers/shared/components/Transaction/CredentialCreate/test/mock_data/CredentialCreate.json
@@ -1,61 +1,61 @@
 {
-  "close_time_iso": "2025-02-18T15:06:22Z",
-  "ctid": "C006630C00000002",
-  "hash": "FADDC5925ACC5A5C567E3C70730E090767A9B22330CFB272005169A7CABA82DB",
-  "ledger_hash": "9C59CCF5A001D6A922A22E59A390D1526E0DF93667C4C13F14C4C23277ACEAD3",
-  "ledger_index": 418572,
+  "close_time_iso": "2025-10-05T13:53:31Z",
+  "ctid": "C000DAA700000002",
+  "hash": "38668D75129E7949649D001907709D1F8DB0FD88232B03CD510707E679AD1E0B",
+  "ledger_hash": "B7DE3742299BE553CC1DE08EFDA3EDE88F94C65B073A623F0C72484F6A9C78C7",
+  "ledger_index": 55975,
   "meta": {
     "AffectedNodes": [
       {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rfEd8iC2g1LVUj75bMkui3yTPcPj6W5Mgr",
+            "Balance": "99999996",
+            "Flags": 0,
+            "OwnerCount": 1,
+            "Sequence": 51131
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "3AFBED20615BECB3DE06CB98E2DD0C905E572E4D279C4B5FD77EB48E110991A4",
+          "PreviousFields": {
+            "Balance": "99999997",
+            "OwnerCount": 0,
+            "Sequence": 51130
+          },
+          "PreviousTxnID": "76E2BEEC3AE4DF755F821BA301CED0DCC56D20BC6ABAB5C4F3717057D9F82D1A",
+          "PreviousTxnLgrSeq": 51555
+        }
+      },
+      {
         "CreatedNode": {
           "LedgerEntryType": "DirectoryNode",
-          "LedgerIndex": "675537AB5EB6416AED24E856E20E5A203FB5A73F0C5D2D92359B5A45184BC594",
+          "LedgerIndex": "A0102CBC99F6B6114ACD2AD065DC41A5517CB5BEA7958FACA106FF2066B8041D",
           "NewFields": {
-            "Owner": "rwXChshgJHh6KwwXY8hN1iNAiuyzJkz7p6",
-            "RootIndex": "675537AB5EB6416AED24E856E20E5A203FB5A73F0C5D2D92359B5A45184BC594"
+            "Owner": "rDeEwcsbGz4GXyGpyRuQo9vRGGT269Jmjk",
+            "RootIndex": "A0102CBC99F6B6114ACD2AD065DC41A5517CB5BEA7958FACA106FF2066B8041D"
           }
         }
       },
       {
         "CreatedNode": {
           "LedgerEntryType": "Credential",
-          "LedgerIndex": "7B685088D546B9E8905D26206F452BB2F44D9A33C9BD9BCF280F7BA39015A955",
+          "LedgerIndex": "C9B22CD799166C336E5F4EE0B85986EC354F1279F2A80C77B4A8B2EEF6EB9517",
           "NewFields": {
-            "CredentialType": "4D7920746573742063726564656E7469616C",
-            "Issuer": "rL6bethyyyphLye6A8WHhw1KxDZrwiqCmi",
-            "Subject": "rwXChshgJHh6KwwXY8hN1iNAiuyzJkz7p6",
-            "URI": "74657374555249"
+            "CredentialType": "56657269666965644163636F756E74",
+            "Expiration": 844523610,
+            "Issuer": "rfEd8iC2g1LVUj75bMkui3yTPcPj6W5Mgr",
+            "Subject": "rDeEwcsbGz4GXyGpyRuQo9vRGGT269Jmjk"
           }
         }
       },
       {
         "CreatedNode": {
           "LedgerEntryType": "DirectoryNode",
-          "LedgerIndex": "7D29B654F46648EA1787141BEC0CB3BAA6B42290955C335F9A7B2F34F9D4ACA0",
+          "LedgerIndex": "D79FCA4F80ABD89F9D0BEBB4B44986D0E5D552DECF4A12947FD2C2493CF55C4A",
           "NewFields": {
-            "Owner": "rL6bethyyyphLye6A8WHhw1KxDZrwiqCmi",
-            "RootIndex": "7D29B654F46648EA1787141BEC0CB3BAA6B42290955C335F9A7B2F34F9D4ACA0"
+            "Owner": "rfEd8iC2g1LVUj75bMkui3yTPcPj6W5Mgr",
+            "RootIndex": "D79FCA4F80ABD89F9D0BEBB4B44986D0E5D552DECF4A12947FD2C2493CF55C4A"
           }
-        }
-      },
-      {
-        "ModifiedNode": {
-          "FinalFields": {
-            "Account": "rL6bethyyyphLye6A8WHhw1KxDZrwiqCmi",
-            "Balance": "99999988",
-            "Flags": 0,
-            "OwnerCount": 1,
-            "Sequence": 418570
-          },
-          "LedgerEntryType": "AccountRoot",
-          "LedgerIndex": "CF3D9A16400DAE31DA3F0FEF511D753C5F7560ECDB8EC9B7F9E92DC837A01F52",
-          "PreviousFields": {
-            "Balance": "100000000",
-            "OwnerCount": 0,
-            "Sequence": 418569
-          },
-          "PreviousTxnID": "B5B9A081FB2113EA2985B819F3014D666D9D4A563A3F7695D7DBB3EC310F92CE",
-          "PreviousTxnLgrSeq": 418569
         }
       }
     ],
@@ -63,19 +63,19 @@
     "TransactionResult": "tesSUCCESS"
   },
   "tx": {
-    "Account": "rL6bethyyyphLye6A8WHhw1KxDZrwiqCmi",
-    "CredentialType": "4D7920746573742063726564656E7469616C",
-    "Fee": "12",
+    "Account": "rfEd8iC2g1LVUj75bMkui3yTPcPj6W5Mgr",
+    "CredentialType": "56657269666965644163636F756E74",
+    "Expiration": 844523610,
+    "Fee": "1",
     "Flags": 0,
-    "LastLedgerSequence": 418590,
-    "Sequence": 418569,
-    "SigningPubKey": "ED8627CFD25412BDC67E6B1F1C219669FFEEF7F8D3D46EA572FBE394FAD3A8F46E",
-    "Subject": "rwXChshgJHh6KwwXY8hN1iNAiuyzJkz7p6",
+    "LastLedgerSequence": 55993,
+    "Sequence": 51130,
+    "SigningPubKey": "ED607EE5D1864691EAF2AB8E20873ECAC397EEFAD7E9D714EFC19F44DBC858BDDE",
+    "Subject": "rDeEwcsbGz4GXyGpyRuQo9vRGGT269Jmjk",
     "TransactionType": "CredentialCreate",
-    "TxnSignature": "D59616E53C8EE14A1584983A7D2661BCE9F30B16C8F4D10B561AB4DA5EC4989F29B344FE182A0F73B2EFCBD0D65E9B4575E1313A48707F08E8445A8BBB4CA50D",
-    "URI": "74657374555249",
-    "date": 793206382,
-    "ledger_index": 418572
+    "TxnSignature": "EDE43649F01BDAC931E5C2477AE77E7C04B82EF3DEA575F3C8C2E553221747F59E6E57A625FA858C019D9709D829ED33B6C2ABBF42C55952B1F5FCE0309F3608",
+    "date": 812987611,
+    "ledger_index": 55975
   },
   "validated": true
 }


### PR DESCRIPTION
## High Level Overview of Change

Fix the incorrect date display of the `Expiration` field in `CredentialCreate` transactions in Simple view.

### Context of Change

The `Expiration` field in `CredentialCreate` transactions was displaying an incorrect date in the Simple view. The timestamp was being converted twice - once by `convertRippleDate()` and then multiplied by `MILLIS_PER_SECOND` again, resulting in an incorrect date far in the future (e.g., `February 19, 58731 at 7:40:00 PM`). This change removes the unnecessary multiplication to display the correct expiration date (e.g., `October 5, 2026 at 1:53:30 PM`).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

## Before / After

#### Before - CredentialCreate Expiration Display
Expiration: February 19, 58731 at 7:40:00 PM

<img width="1049" height="669" alt="before" src="https://github.com/user-attachments/assets/b2a69d5c-db7f-425e-a38a-6ee0a15cd916" />

#### After - CredentialCreate Expiration Display
Expiration: October 5, 2026 at 1:53:30 PM

<img width="1025" height="668" alt="after" src="https://github.com/user-attachments/assets/8102d73d-34bf-4789-9089-818a282b5bfc" />

## Test Plan

- [x] **Unit Tests**
- [x] **Manual Tests**
  1. `npm run build && npm start`
  2. Visit transaction detail page for CredentialCreate transactions with Expiration field and confirm that the date displays correctly in Simple view
