### PR TITLE
Extract info card style into shared file

### DIFF
--- a/src/containers/AMMPool/InfoCards/AuctionCard.tsx
+++ b/src/containers/AMMPool/InfoCards/AuctionCard.tsx
@@ -123,7 +123,7 @@ export const AuctionCard: FC<AuctionCardProps> = ({
     replacementCostRaw != null ? getLPTokenUSD(replacementCostRaw) : null
 
   return (
-    <div className="amm-pool-info-card">
+    <div className="info-card">
       <h3 className="info-card-title">
         <AuctionIcon className="info-card-icon" />
         {t('auction')}
@@ -142,7 +142,6 @@ export const AuctionCard: FC<AuctionCardProps> = ({
             )}
           </span>
         </div>
-        <div className="info-card-separator" />
         <div className="info-card-row">
           <span className="info-card-label">{t('expiration')}</span>
           <span className="info-card-value">
@@ -155,14 +154,12 @@ export const AuctionCard: FC<AuctionCardProps> = ({
               : '--'}
           </span>
         </div>
-        <div className="info-card-separator" />
         <div className="info-card-row">
           <span className="info-card-label">{t('discounted_fee')}</span>
           <span className="info-card-value info-card-value-orange">
             {discountedFee}
           </span>
         </div>
-        <div className="info-card-separator" />
         <div className="info-card-row">
           <span className="info-card-label">{t('price_paid')}</span>
           <span className="info-card-value">
@@ -182,7 +179,6 @@ export const AuctionCard: FC<AuctionCardProps> = ({
             )}
           </span>
         </div>
-        <div className="info-card-separator" />
         <div className="info-card-row">
           <span className="info-card-label">{t('replacement_cost')}</span>
           <span className="info-card-value">

--- a/src/containers/AMMPool/InfoCards/BasicInfoCard.tsx
+++ b/src/containers/AMMPool/InfoCards/BasicInfoCard.tsx
@@ -38,7 +38,7 @@ export const BasicInfoCard: FC<BasicInfoCardProps> = ({
     : '--'
 
   return (
-    <div className="amm-pool-info-card">
+    <div className="info-card">
       <h3 className="info-card-title">
         <BasicInfoIcon className="info-card-icon" />
         {t('basic_info')}
@@ -54,29 +54,24 @@ export const BasicInfoCard: FC<BasicInfoCardProps> = ({
           </span>
         </div>
         {lpTokenCurrency && (
-          <>
-            <div className="info-card-separator" />
-            <div className="info-card-row">
-              <span className="info-card-label">
-                {t('lp_token_currency_code')}
-              </span>
-              <span className="info-card-value">
-                <CopyableText
-                  text={lpTokenCurrency}
-                  displayText={shortenLPToken(lpTokenCurrency)}
-                />
-              </span>
-            </div>
-          </>
+          <div className="info-card-row">
+            <span className="info-card-label">
+              {t('lp_token_currency_code')}
+            </span>
+            <span className="info-card-value">
+              <CopyableText
+                text={lpTokenCurrency}
+                displayText={shortenLPToken(lpTokenCurrency)}
+              />
+            </span>
+          </div>
         )}
-        <div className="info-card-separator" />
         <div className="info-card-row">
           <span className="info-card-label">{t('trading_fee')}</span>
           <span className="info-card-value info-card-value-orange">
             {tradingFeePercent}%
           </span>
         </div>
-        <div className="info-card-separator" />
         <div className="info-card-row">
           <span className="info-card-label">{t('created_on')}</span>
           <span className="info-card-value">{createdDate}</span>

--- a/src/containers/AMMPool/InfoCards/MarketDataCard.tsx
+++ b/src/containers/AMMPool/InfoCards/MarketDataCard.tsx
@@ -68,7 +68,7 @@ export const MarketDataCard: FC<MarketDataCardProps> = ({
   )
 
   return (
-    <div className="amm-pool-info-card">
+    <div className="info-card">
       <h3 className="info-card-title">
         <MarketDataIcon className="info-card-icon" />
         {t('market_data')}
@@ -84,7 +84,6 @@ export const MarketDataCard: FC<MarketDataCardProps> = ({
                   : '--'}
               </span>
             </div>
-            <div className="info-card-separator" />
             <div className="info-card-row">
               <span className="info-card-label">
                 {t('volume_24h')}
@@ -96,7 +95,6 @@ export const MarketDataCard: FC<MarketDataCardProps> = ({
                   : '--'}
               </span>
             </div>
-            <div className="info-card-separator" />
             <div className="info-card-row">
               <span className="info-card-label">
                 {t('fees_24h')}
@@ -108,7 +106,6 @@ export const MarketDataCard: FC<MarketDataCardProps> = ({
                   : '--'}
               </span>
             </div>
-            <div className="info-card-separator" />
             <div className="info-card-row">
               <span className="info-card-label">
                 {t('apr_24h')}
@@ -123,49 +120,40 @@ export const MarketDataCard: FC<MarketDataCardProps> = ({
           </>
         )}
         {balance1 && (
-          <>
-            <div className="info-card-separator" />
-            <div className="info-card-row">
-              <BalanceLabel
-                currency={balance1.currency}
-                issuer={balance1.issuer}
-              />
-              <span className="info-card-value">
-                {parseAmount(balance1.amount)}
-              </span>
-            </div>
-          </>
+          <div className="info-card-row">
+            <BalanceLabel
+              currency={balance1.currency}
+              issuer={balance1.issuer}
+            />
+            <span className="info-card-value">
+              {parseAmount(balance1.amount)}
+            </span>
+          </div>
         )}
         {balance2 && (
-          <>
-            <div className="info-card-separator" />
-            <div className="info-card-row">
-              <BalanceLabel
-                currency={balance2.currency}
-                issuer={balance2.issuer}
-              />
-              <span className="info-card-value">
-                {parseAmount(balance2.amount)}
-              </span>
-            </div>
-          </>
+          <div className="info-card-row">
+            <BalanceLabel
+              currency={balance2.currency}
+              issuer={balance2.issuer}
+            />
+            <span className="info-card-value">
+              {parseAmount(balance2.amount)}
+            </span>
+          </div>
         )}
         {lpTokenBalance && (
-          <>
-            <div className="info-card-separator" />
-            <div className="info-card-row">
-              <span className="info-card-label">{t('lp_tokens')}</span>
-              <span className="info-card-value">
-                <div>{parseAmount(lpTokenBalance)}</div>
-                {losData && (
-                  <div className="info-card-subtitle">
-                    {parseIntegerAmount(losData.liquidity_provider_count)}{' '}
-                    {t('liquidity_providers')}
-                  </div>
-                )}
-              </span>
-            </div>
-          </>
+          <div className="info-card-row">
+            <span className="info-card-label">{t('lp_tokens')}</span>
+            <span className="info-card-value">
+              <div>{parseAmount(lpTokenBalance)}</div>
+              {losData && (
+                <div className="info-card-subtitle">
+                  {parseIntegerAmount(losData.liquidity_provider_count)}{' '}
+                  {t('liquidity_providers')}
+                </div>
+              )}
+            </span>
+          </div>
         )}
       </div>
     </div>

--- a/src/containers/AMMPool/styles.scss
+++ b/src/containers/AMMPool/styles.scss
@@ -1,6 +1,7 @@
 @use '../shared/css/variables' as *;
 @use '../shared/css/table';
 @use '../shared/css/data-tables-notice';
+@use '../shared/css/info-card';
 
 .amm-pool-page {
   .loader {
@@ -136,102 +137,6 @@
   @include for-size(desktop-up) {
     gap: 32px;
     grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.amm-pool-info-card {
-  padding: 24px;
-  border: 1px solid $black-60;
-  border-radius: 8px;
-  background: $black-80;
-
-  .info-card-title {
-    display: flex;
-    align-items: center;
-    margin: 0 0 16px;
-    color: $white;
-    font-size: 20px;
-    gap: 8px;
-    @include bold;
-  }
-
-  .info-card-icon {
-    width: 24px;
-    height: 24px;
-    flex-shrink: 0;
-  }
-
-  .info-card-rows {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  .info-card-row {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 4px;
-
-    &:not(:last-child)::after {
-      display: none;
-    }
-  }
-
-  .info-card-separator {
-    width: 100%;
-    height: 1px;
-    background: $black-60;
-  }
-
-  .info-card-label {
-    display: flex;
-    align-items: center;
-    color: $black-40;
-    font-size: 14px;
-    line-height: 1.5;
-    text-transform: uppercase;
-    @include semibold;
-
-    .hover {
-      width: 14px;
-      height: 14px;
-      margin-left: 4px;
-      cursor: default;
-    }
-  }
-
-  .info-card-value {
-    color: $white;
-    font-size: 14px;
-    line-height: 1.5;
-    text-align: right;
-    word-break: break-all;
-    @include regular;
-
-    &-green {
-      color: $green;
-    }
-
-    &-orange {
-      color: $orange;
-    }
-
-    &-link {
-      color: $green-30;
-
-      a {
-        color: $green-30;
-      }
-    }
-  }
-
-  .info-card-subtitle {
-    margin-top: 4px;
-    color: $black-40;
-    font-size: 12px;
-    line-height: 1.5;
-    @include regular;
   }
 }
 

--- a/src/containers/AMMRankings/GeneralInfoCard.tsx
+++ b/src/containers/AMMRankings/GeneralInfoCard.tsx
@@ -53,55 +53,51 @@ export const GeneralInfoCard: FC<GeneralInfoCardProps> = ({
   )
 
   return (
-    <div className="general-info-card">
-      <div className="card-header">
-        <InfoIcon className="info-icon" />
-        <span className="card-title">{t('general_info')}</span>
-      </div>
-
-      <div className="stats-container">
-        <div className="stat-row">
-          <div className="stat-label">
+    <div className="info-card">
+      <h3 className="info-card-title">
+        <InfoIcon className="info-card-icon" />
+        {t('general_info')}
+      </h3>
+      <div className="info-card-rows">
+        <div className="info-card-row">
+          <span className="info-card-label">
             {t('tvl')}
             {renderTooltip('tvl')}
-          </div>
-          <div className="stat-value">
+          </span>
+          <span className="info-card-value">
             {tvl ? formatCurrencyAmount(tvl) : DEFAULT_EMPTY_VALUE}
-          </div>
+          </span>
         </div>
-
-        <div className="stat-row">
-          <div className="stat-label">
+        <div className="info-card-row">
+          <span className="info-card-label">
             {t('number_of_amms')}
             {renderTooltip('number_of_amms')}
-          </div>
-          <div className="stat-value">
+          </span>
+          <span className="info-card-value">
             {stats.amm_pool_count
               ? stats.amm_pool_count.toLocaleString()
               : DEFAULT_EMPTY_VALUE}
-          </div>
+          </span>
         </div>
-
-        <div className="stat-row">
-          <div className="stat-label">
+        <div className="info-card-row">
+          <span className="info-card-label">
             {t('number_of_lps')}
             {renderTooltip('number_of_lps')}
-          </div>
-          <div className="stat-value">
+          </span>
+          <span className="info-card-value">
             {stats.liquidity_provider_count
               ? stats.liquidity_provider_count.toLocaleString()
               : DEFAULT_EMPTY_VALUE}
-          </div>
+          </span>
         </div>
-
-        <div className="stat-row">
-          <div className="stat-label">
+        <div className="info-card-row">
+          <span className="info-card-label">
             {t('volume_24h' as any)}
             {renderTooltip('volume_24h_all')}
-          </div>
-          <div className="stat-value">
+          </span>
+          <span className="info-card-value">
             {volume24h ? formatCurrencyAmount(volume24h) : DEFAULT_EMPTY_VALUE}
-          </div>
+          </span>
         </div>
       </div>
     </div>

--- a/src/containers/AMMRankings/ammRankings.scss
+++ b/src/containers/AMMRankings/ammRankings.scss
@@ -1,5 +1,6 @@
 @use '../shared/css/variables' as *;
 @use '../shared/css/table';
+@use '../shared/css/info-card';
 
 .amm-rankings-page {
   overflow: visible;
@@ -28,7 +29,7 @@
     flex-direction: column-reverse;
     align-items: stretch;
     margin-bottom: 64px;
-    gap: 16px;
+    gap: 32px;
 
     @include for-size(desktop-up) {
       flex-direction: row;
@@ -50,71 +51,13 @@
   // ─── General Info Card ────────────────────────────────────────
   // Align the top of the card with the top of the chart container,
   // accounting for the section title + controls above the chart.
-  .general-info-card {
+  .info-card {
     @include for-size(desktop-up) {
       min-width: 200px;
       max-width: 320px;
       flex: 1;
       // Offset = chart-section-title height + margin + controls height + margin
       margin-top: 84px;
-    }
-
-    padding: 20px 24px;
-    border: 1px solid $black-70;
-    border-radius: $border-radius;
-    background-color: $black-80;
-
-    .card-header {
-      display: flex;
-      align-items: center;
-      margin-bottom: 16px;
-      gap: 8px;
-
-      .info-icon {
-        width: 20px;
-        height: 20px;
-        color: $white;
-      }
-
-      .card-title {
-        color: $white;
-        font-size: 16px;
-        @include semibold;
-      }
-    }
-
-    .stats-container {
-      display: flex;
-      flex-direction: column;
-
-      .stat-row {
-        display: flex;
-        align-items: baseline;
-        justify-content: space-between;
-        padding: 12px 0;
-        border-bottom: 1px solid $black-70;
-
-        &:first-child {
-          padding-top: 0;
-        }
-
-        .stat-label {
-          display: inline-flex;
-          align-items: center;
-          color: $black-40;
-          font-size: 14px;
-          gap: 6px;
-          letter-spacing: 0.5px;
-          text-transform: uppercase;
-          @include bold;
-        }
-
-        .stat-value {
-          color: $white;
-          font-size: 14px;
-          font-weight: normal;
-        }
-      }
     }
   }
 

--- a/src/containers/shared/css/info-card.scss
+++ b/src/containers/shared/css/info-card.scss
@@ -1,0 +1,131 @@
+@use './variables' as *;
+
+/*
+ * Shared styles for info cards that display a title with an icon and a list
+ * of label/value rows separated by horizontal dividers.
+ *
+ * Usage:
+ *   @use '../shared/css/info-card';
+ *
+ *   <div class="info-card">
+ *     <h3 class="info-card-title">
+ *       <Icon class="info-card-icon" />
+ *       Title
+ *     </h3>
+ *     <div class="info-card-rows">
+ *       <div class="info-card-row">
+ *         <span class="info-card-label">Label</span>
+ *         <span class="info-card-value">Value</span>
+ *       </div>
+ *       ...more rows
+ *     </div>
+ *   </div>
+ *
+ * Dividers between rows are added automatically via CSS — do not include
+ * separator elements.
+ *
+ * Modifier classes for values:
+ *   info-card-value-green   — success/active state
+ *   info-card-value-orange  — warning/attention state
+ *   info-card-value-link    — clickable link appearance
+ *
+ * Use info-card-subtitle for secondary text within a value cell.
+ */
+
+.info-card {
+  padding: 24px;
+  border: 1px solid $black-60;
+  border-radius: 8px;
+  background: $black-80;
+
+  .info-card-title {
+    display: flex;
+    align-items: center;
+    margin: 0 0 16px;
+    color: $white;
+    font-size: 20px;
+    gap: 8px;
+    @include bold;
+  }
+
+  .info-card-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+  }
+
+  .info-card-rows {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .info-card-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 10px 0;
+    gap: 4px;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid $black-60;
+    }
+
+    &:first-child {
+      padding-top: 0;
+    }
+
+    &:last-child {
+      padding-bottom: 0;
+    }
+  }
+
+  .info-card-label {
+    display: flex;
+    align-items: center;
+    color: $black-40;
+    font-size: 14px;
+    line-height: 1.5;
+    text-transform: uppercase;
+    @include semibold;
+
+    .hover {
+      width: 14px;
+      height: 14px;
+      margin-left: 4px;
+      cursor: default;
+    }
+  }
+
+  .info-card-value {
+    color: $white;
+    font-size: 14px;
+    line-height: 1.5;
+    text-align: right;
+    word-break: break-all;
+    @include regular;
+
+    &-green {
+      color: $green;
+    }
+
+    &-orange {
+      color: $orange;
+    }
+
+    &-link {
+      color: $green-30;
+
+      a {
+        color: $green-30;
+      }
+    }
+  }
+
+  .info-card-subtitle {
+    margin-top: 4px;
+    color: $black-40;
+    font-size: 12px;
+    line-height: 1.5;
+    @include regular;
+  }
+}


### PR DESCRIPTION
## High Level Overview of Change

Extract the shared card styles used by the AMM Pool page (Basic Info, Market Data, Auction) and the AMM Rankings page (General Info) into a single [`src/containers/shared/css/info-card.scss`](src/containers/shared/css/info-card.scss).

Changes:
- New shared `info-card.scss` with documented usage and CSS-based row dividers (replaces explicit `<div className="info-card-separator" />` elements)
- `AMMPool/styles.scss` and `AMMRankings/ammRankings.scss` import the shared styles instead of defining their own card rules
- `BasicInfoCard`, `MarketDataCard`, `AuctionCard` wrapper class renamed `amm-pool-info-card` → `info-card`; separator `<div>`s removed
- `GeneralInfoCard` refactored to use the shared `info-card` class structure (was using bespoke `general-info-card` / `stat-row` / `stat-label` etc.)
- Increased gap between the General Info card and the TVL/Volume chart on the AMM Rankings page from 16px → 32px

### Context of Change

The AMM Pool page and AMM Rankings page both display info cards with the same visual pattern — an icon title followed by label/value rows separated by horizontal dividers. They were implemented independently with different class names (`amm-pool-info-card` vs `general-info-card`) and different structures, leading to visual inconsistencies and duplicate CSS.

Consolidating to a single shared stylesheet:
- Guarantees visual consistency across both pages
- Removes ~95 lines of duplicated SCSS
- Lets future pages adopt the same pattern with a single `@use` import
- CSS-based row dividers eliminate the need for explicit separator elements in JSX (cleaner markup)

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### Codebase Modernization

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

## Before / After

**Before**: Two sets of info card styles — `amm-pool-info-card` in AMMPool/styles.scss and `general-info-card` in ammRankings.scss — with different spacing, structure, and class names.
<img width="1371" height="650" alt="Screenshot 2026-04-17 at 3 31 43 PM" src="https://github.com/user-attachments/assets/c1c173b8-d2a9-4979-918e-efeddc72b609" />

**After**: Single shared `info-card.scss` used by both pages. All four cards (Basic Info, Market Data, Auction, General Info) now use identical class names (`info-card`, `info-card-title`, `info-card-icon`, `info-card-rows`, `info-card-row`, `info-card-label`, `info-card-value`). Visual appearance is unchanged for the AMM Pool page; the General Info card on the Rankings page now matches the AMM Pool cards exactly.
<img width="1364" height="654" alt="Screenshot 2026-04-17 at 3 31 32 PM" src="https://github.com/user-attachments/assets/3364c10c-6717-4831-9400-8260fcbbd1db" />

## Test Plan

1. All existing unit tests pass
2. Lint and style check pass
3. Manually verified visual appearance on both `/amm/:id` and `/amm` pages matches before the refactor
