### PR TITLE
feat(validators): display base_fee in drops on Fee Voting table (#1206)

### DIFF
--- a/public/locales/ca-CA/translations.json
+++ b/public/locales/ca-CA/translations.json
@@ -385,6 +385,7 @@
   "missed_validations": "{{count}} validacions perdudes",
   "incomplete": "incomplet",
   "base_fee": "Comissío Base",
+  "drops": null,
   "account_reserve": "Reserva de Compte",
   "object_reserve": "Reserva d'Objectes",
   "vote": "Vota",

--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -386,6 +386,7 @@
   "missed_validations": "{{count}} missed validations",
   "incomplete": "incomplete",
   "base_fee": "Base Fee",
+  "drops": "drops",
   "account_reserve": "Account Reserve",
   "object_reserve": "Object Reserve",
   "vote": "Vote",

--- a/public/locales/es-ES/translations.json
+++ b/public/locales/es-ES/translations.json
@@ -386,6 +386,7 @@
   "missed_validations": "{{count}} validaciones perdidas",
   "incomplete": "incompleto",
   "base_fee": null,
+  "drops": null,
   "account_reserve": null,
   "object_reserve": null,
   "vote": null,

--- a/public/locales/fr-FR/translations.json
+++ b/public/locales/fr-FR/translations.json
@@ -386,6 +386,7 @@
   "missed_validations": "{{count}} validations manquées",
   "incomplete": "incomplet",
   "base_fee": null,
+  "drops": null,
   "account_reserve": null,
   "object_reserve": null,
   "vote": null,

--- a/public/locales/ja-JP/translations.json
+++ b/public/locales/ja-JP/translations.json
@@ -386,6 +386,7 @@
   "missed_validations": "バリデーション失敗数:{{count}}",
   "incomplete": null,
   "base_fee": "基本手数料",
+  "drops": null,
   "account_reserve": "アカウント準備金",
   "object_reserve": "オブジェクト準備金",
   "vote": "投票",

--- a/public/locales/ko-KR/translations.json
+++ b/public/locales/ko-KR/translations.json
@@ -386,6 +386,7 @@
   "missed_validations": "{{count}}회의 유효성 검증이 누락되었습니다",
   "incomplete": "미완료",
   "base_fee": null,
+  "drops": null,
   "account_reserve": null,
   "object_reserve": null,
   "vote": null,

--- a/public/locales/my-MM/translations.json
+++ b/public/locales/my-MM/translations.json
@@ -386,6 +386,7 @@
   "missed_validations": "{{count}} ခု အတည်ပြုမှု လွဲချော်",
   "incomplete": "မပြီးပြည့်စုံ",
   "base_fee": "အခြေခံ အခကြေးငွေ",
+  "drops": null,
   "account_reserve": "အကောင့် သီးသန့်ငွေ",
   "object_reserve": "အရာဝတ္ထု သီးသန့်ငွေ",
   "vote": "မဲပေးရန်",

--- a/src/containers/Network/ValidatorsTable.tsx
+++ b/src/containers/Network/ValidatorsTable.tsx
@@ -88,7 +88,11 @@ export const ValidatorsTable = (props: ValidatorsTableProps) => {
               <DownIcon className="fee-icon" title={pubkey} alt={pubkey} />
             </span>
           ))}
-        <span>{renderXRP(data / DROPS_TO_XRP_FACTOR, language)}</span>
+        {className === 'base_fee' ? (
+          <span>{`${data} ${t('drops')}`}</span>
+        ) : (
+          <span>{renderXRP(data / DROPS_TO_XRP_FACTOR, language)}</span>
+        )}
       </td>
     ) : (
       <td className={`${className} vote`} />

--- a/src/containers/Network/test/validatorsTable.test.js
+++ b/src/containers/Network/test/validatorsTable.test.js
@@ -51,7 +51,7 @@ describe('Validators table', () => {
       '0.20',
     )
     expect(container.querySelector('td.base_fee').textContent.trim()).toContain(
-      '0.00001',
+      '10 drops',
     )
   })
 })

--- a/src/containers/Validators/VotingTab.tsx
+++ b/src/containers/Validators/VotingTab.tsx
@@ -89,7 +89,7 @@ export const VotingTab: FC<{
       <div className="metrics metrics-voting">
         <div className="cell">
           <div className="label">{t('base_fee')}</div>
-          <div>{renderXRP(validatorData.base_fee / XRP_BASE)}</div>
+          <div>{`${validatorData.base_fee} ${t('drops')}`}</div>
         </div>
         <div className="cell">
           <div className="label">{t('account_reserve')}</div>

--- a/src/containers/Validators/test/VotingTab.test.tsx
+++ b/src/containers/Validators/test/VotingTab.test.tsx
@@ -67,7 +67,7 @@ describe('VotingTab container', () => {
 
     // Render fees voting correctly
     const cells = container.querySelectorAll('.metrics .cell')
-    expect(cells[0].innerHTML).toContain('0.00001')
+    expect(cells[0].innerHTML).toContain('10 drops')
     expect(cells[1].innerHTML).toContain('10.00')
     expect(cells[2].innerHTML).toContain('2.00')
 


### PR DESCRIPTION
## High Level Overview of Change

Closes #1206.

Renders validator `base_fee` in drops on both the Validators Fee Voting table and the Validator detail page's voting tab (for example `10 drops` instead of `0.00001` XRP). Reserve voting columns (`reserve_base`, `reserve_inc`) keep their XRP formatting because those values are large enough to read as XRP already.

### Context of Change

The Fee Voting table's `base_fee` column goes through `renderFeeVoting` in `src/containers/Network/ValidatorsTable.tsx`, which converts the raw drops value to XRP and runs it through `renderXRP`. For `reserve_base` and `reserve_inc` that produces readable amounts (`1.00`, `0.20`), but `base_fee` defaults to 10 drops and surfaces as `0.00001`, which is harder to scan and disconnected from how validator operators actually talk about the reference fee.

The fix gates the XRP conversion on the column's className. When the cell renders the `base_fee` column, show the raw drops value with a translated `drops` suffix; otherwise, keep the existing XRP path untouched. The same rule is applied to the `base_fee` cell on `VotingTab.tsx` so the individual validator page stays consistent with the table.

I also added a `drops` string to `public/locales/en-US/translations.json`. Other locale bundles fall back to the English string via the project's existing `fallbackLng: 'en-US'` configuration until translators catch up.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates

### Codebase Modernization

- [ ] Yes, this PR modernizes the codebase.
- [x] No, this PR does not modernize the codebase.

### Before / After

Before: the `BASE FEE` cell on the validators Fee Voting table and on the individual validator's voting tab rendered `0.00001` for a typical 10-drop reference fee, because the value was divided by `DROPS_TO_XRP_FACTOR` and formatted through `renderXRP`. Downward/upward vote indicators still rendered, but the magnitude was hard to read at a glance.

After: the same cells render `10 drops` (or whatever drops value the validator is voting for). Vote direction indicators are unchanged. Reserve columns (`base`, `owner`) continue to use the XRP formatting because those values are large enough to read as XRP.

### Test Plan

- `npx jest --env=jsdom --testPathPatterns='Validators|Voting'` — 6 test suites, 21 tests passing.
- `validatorsTable.test.js` now asserts `'10 drops'` for the `td.base_fee` cell (was `'0.00001'`).
- `VotingTab.test.tsx` now asserts `'10 drops'` for the first `.metrics .cell` (was `'0.00001'`).
- Manual review of the rendered output against the issue description (small BASE FEE values are easier to scan as integer drops).

### Future Tasks

- Add `drops` translations to the other locale bundles (`ja-JP`, `ko-KR`, `es-ES`, `fr-FR`, `ca-CA`, `my-MM`). Until then those locales fall back to the English string via the project's existing `fallbackLng: 'en-US'` configuration.
