### PR TITLE
  fix: Reject non-Vault ledger entries in getVault

### DIFF
--- a/src/rippled/lib/rippled.ts
+++ b/src/rippled/lib/rippled.ts
@@ -876,6 +876,10 @@ const getVault = (rippledSocket, vaultId) =>
       throw new Error(resp.error_message, 500)
     }
 
+    if (resp.node?.LedgerEntryType !== 'Vault') {
+      throw new Error('Not a Vault', 404)
+    }
+
     return resp.node
   })
 

--- a/src/rippled/lib/rippled.ts
+++ b/src/rippled/lib/rippled.ts
@@ -594,6 +594,10 @@ const getNegativeUNL = async (
     throw new Error(resp.error_message, 500)
   }
 
+  if (resp.node?.LedgerEntryType !== 'NegativeUNL') {
+    throw new Error('Not a NegativeUNL', 404)
+  }
+
   return resp
 }
 
@@ -727,6 +731,10 @@ const getMPTIssuance = async (
 
   if (resp.error_message) {
     throw new Error(resp.error_message, 500)
+  }
+
+  if (resp.node?.LedgerEntryType !== 'MPTokenIssuance') {
+    throw new Error('Not an MPTokenIssuance', 404)
   }
 
   return resp
@@ -904,6 +912,10 @@ const getLoanBroker = (rippledSocket, loanBrokerId) =>
 
     if (resp.error_message) {
       throw new Error(resp.error_message, 500)
+    }
+
+    if (resp.node?.LedgerEntryType !== 'LoanBroker') {
+      throw new Error('Not a LoanBroker', 404)
     }
 
     return resp.node

--- a/src/rippled/lib/test/rippled.test.ts
+++ b/src/rippled/lib/test/rippled.test.ts
@@ -1,8 +1,13 @@
-import { getVault } from '../rippled'
+import {
+  getVault,
+  getLoanBroker,
+  getMPTIssuance,
+  getNegativeUNL,
+} from '../rippled'
 
-// TODO: Future revisions should add unit-test coverage for the other methods
-// exported from src/rippled/lib/rippled.ts (getTransaction, getLedger,
-// getNFTInfo, getAccountInfo, getLoanBroker, etc.). Each has its own
+// TODO: Future revisions should add unit-test coverage for the remaining
+// methods exported from src/rippled/lib/rippled.ts (getTransaction, getLedger,
+// getNFTInfo, getAccountInfo, getLedgerEntry, etc.). Each has its own
 // error-handling branches that deserve direct coverage.
 
 const VAULT_INDEX =
@@ -101,5 +106,128 @@ describe('getVault', () => {
       message: 'unexpected failure',
       code: 500,
     })
+  })
+})
+
+describe('getLoanBroker', () => {
+  const LOAN_BROKER_INDEX =
+    '1111111111111111111111111111111111111111111111111111111111111111'
+
+  it('returns resp.node when the ledger entry is a LoanBroker', async () => {
+    const node = {
+      LedgerEntryType: 'LoanBroker',
+      Owner: 'rExampleLoanBrokerOwner',
+      index: LOAN_BROKER_INDEX,
+    }
+    const socket = makeSocket({ index: LOAN_BROKER_INDEX, node })
+
+    await expect(getLoanBroker(socket, LOAN_BROKER_INDEX)).resolves.toEqual(
+      node,
+    )
+  })
+
+  it('throws when the ledger entry is not a LoanBroker (e.g. Check)', async () => {
+    const socket = makeSocket({
+      index: LOAN_BROKER_INDEX,
+      node: {
+        LedgerEntryType: 'Check',
+        Account: 'rExampleCheckSender',
+        index: LOAN_BROKER_INDEX,
+      },
+    })
+
+    await expect(
+      getLoanBroker(socket, LOAN_BROKER_INDEX),
+    ).rejects.toMatchObject({
+      message: 'Not a LoanBroker',
+      code: 404,
+    })
+  })
+
+  it('throws "LoanBroker not found" when rippled returns entryNotFound', async () => {
+    const socket = makeSocket({ error: 'entryNotFound' })
+
+    await expect(
+      getLoanBroker(socket, LOAN_BROKER_INDEX),
+    ).rejects.toMatchObject({
+      message: 'LoanBroker not found',
+      code: 404,
+    })
+  })
+})
+
+describe('getMPTIssuance', () => {
+  const MPT_ID = '00002AF2588C244FE5F74BF48B5C5E2823235B243AA34634'
+
+  it('returns the full response when the ledger entry is an MPTokenIssuance', async () => {
+    const resp = {
+      node: {
+        LedgerEntryType: 'MPTokenIssuance',
+        Issuer: 'rExampleMPTIssuer',
+        Sequence: 1,
+      },
+      ledger_index: 100,
+      validated: true,
+    }
+    const socket = makeSocket(resp)
+
+    await expect(getMPTIssuance(socket, MPT_ID)).resolves.toEqual(resp)
+  })
+
+  it('throws when the ledger entry is not an MPTokenIssuance', async () => {
+    const socket = makeSocket({
+      node: {
+        LedgerEntryType: 'Vault',
+        Owner: 'rExampleVaultOwner',
+      },
+      validated: true,
+    })
+
+    await expect(getMPTIssuance(socket, MPT_ID)).rejects.toMatchObject({
+      message: 'Not an MPTokenIssuance',
+      code: 404,
+    })
+  })
+
+  it('throws "MPT Issuance not found" when rippled returns entryNotFound', async () => {
+    const socket = makeSocket({ error: 'entryNotFound' })
+
+    await expect(getMPTIssuance(socket, MPT_ID)).rejects.toMatchObject({
+      message: 'MPT Issuance not found',
+      code: 404,
+    })
+  })
+})
+
+describe('getNegativeUNL', () => {
+  it('returns the full response when the ledger entry is a NegativeUNL', async () => {
+    const resp = {
+      node: {
+        LedgerEntryType: 'NegativeUNL',
+        DisabledValidators: [],
+      },
+      validated: true,
+    }
+    const socket = makeSocket(resp)
+
+    await expect(getNegativeUNL(socket)).resolves.toEqual(resp)
+  })
+
+  it('throws when the ledger entry is not a NegativeUNL', async () => {
+    const socket = makeSocket({
+      node: { LedgerEntryType: 'AccountRoot' },
+      validated: true,
+    })
+
+    await expect(getNegativeUNL(socket)).rejects.toMatchObject({
+      message: 'Not a NegativeUNL',
+      code: 404,
+    })
+  })
+
+  it('returns [] when the entry is missing', async () => {
+    const socket = makeSocket({ error: 'entryNotFound' })
+
+    await expect(getNegativeUNL(socket)).resolves.toEqual([])
   })
 })

--- a/src/rippled/lib/test/rippled.test.ts
+++ b/src/rippled/lib/test/rippled.test.ts
@@ -5,11 +5,6 @@ import {
   getNegativeUNL,
 } from '../rippled'
 
-// TODO: Future revisions should add unit-test coverage for the remaining
-// methods exported from src/rippled/lib/rippled.ts (getTransaction, getLedger,
-// getNFTInfo, getAccountInfo, getLedgerEntry, etc.). Each has its own
-// error-handling branches that deserve direct coverage.
-
 const VAULT_INDEX =
   'EF98FDBA404CBEB4F746DA1026B859E260BBB459D111268F6A26BBC7C4811A04'
 

--- a/src/rippled/lib/test/rippled.test.ts
+++ b/src/rippled/lib/test/rippled.test.ts
@@ -1,0 +1,105 @@
+import { getVault } from '../rippled'
+
+// TODO: Future revisions should add unit-test coverage for the other methods
+// exported from src/rippled/lib/rippled.ts (getTransaction, getLedger,
+// getNFTInfo, getAccountInfo, getLoanBroker, etc.). Each has its own
+// error-handling branches that deserve direct coverage.
+
+const VAULT_INDEX =
+  'EF98FDBA404CBEB4F746DA1026B859E260BBB459D111268F6A26BBC7C4811A04'
+
+const makeSocket = (response: any) =>
+  ({ send: jest.fn().mockResolvedValue(response) }) as any
+
+describe('getVault', () => {
+  it('queries ledger_entry with the supplied vault id', async () => {
+    const socket = makeSocket({
+      node: { LedgerEntryType: 'Vault', index: VAULT_INDEX },
+    })
+
+    await getVault(socket, VAULT_INDEX)
+
+    expect(socket.send).toHaveBeenCalledWith({
+      command: 'ledger_entry',
+      index: VAULT_INDEX,
+      ledger_index: 'validated',
+    })
+  })
+
+  it('returns resp.node when the ledger entry is a Vault', async () => {
+    const node = {
+      LedgerEntryType: 'Vault',
+      Owner: 'rExampleVaultOwner',
+      index: VAULT_INDEX,
+    }
+    const socket = makeSocket({ index: VAULT_INDEX, node, validated: true })
+
+    await expect(getVault(socket, VAULT_INDEX)).resolves.toEqual(node)
+  })
+
+  it('throws when the ledger entry is not a Vault', async () => {
+    // Real devnet response captured 2026-04-27 — this index resolves to a
+    // PermissionedDomain, not a Vault.
+    const socket = makeSocket({
+      index: VAULT_INDEX,
+      node: {
+        LedgerEntryType: 'PermissionedDomain',
+        Owner: 'rKhgwxANWk65QtQziFGeh6AfYwchpnvzzk',
+        index: VAULT_INDEX,
+      },
+      validated: true,
+    })
+
+    await expect(getVault(socket, VAULT_INDEX)).rejects.toMatchObject({
+      message: 'Not a Vault',
+      code: 404,
+    })
+  })
+
+  it('throws "Vault not found" when rippled returns entryNotFound', async () => {
+    const socket = makeSocket({ error: 'entryNotFound' })
+
+    await expect(getVault(socket, VAULT_INDEX)).rejects.toMatchObject({
+      message: 'Vault not found',
+      code: 404,
+    })
+  })
+
+  it('throws on invalidParams', async () => {
+    const socket = makeSocket({ error_message: 'invalidParams' })
+
+    await expect(getVault(socket, VAULT_INDEX)).rejects.toMatchObject({
+      message: 'invalidParams for ledger_entry',
+      code: 404,
+    })
+  })
+
+  it('throws on lgrNotFound', async () => {
+    const socket = makeSocket({ error_message: 'lgrNotFound' })
+
+    await expect(getVault(socket, VAULT_INDEX)).rejects.toMatchObject({
+      message: 'invalid ledger index/hash',
+      code: 400,
+    })
+  })
+
+  it('throws "Invalid vault ID format" for non-hex ids', async () => {
+    const socket = makeSocket({
+      error_message: '"1234" is not hex string',
+    })
+
+    await expect(getVault(socket, '1234')).rejects.toMatchObject({
+      message: 'Invalid vault ID format',
+      code: 400,
+    })
+  })
+
+  it('throws a 500 for any other error_message', async () => {
+    const socket = makeSocket({ error_message: 'unexpected failure' })
+
+    await expect(getVault(socket, VAULT_INDEX)).rejects.toMatchObject({
+      message: 'unexpected failure',
+      code: 500,
+    })
+  })
+})


### PR DESCRIPTION


## High Level Overview of Change
The existing implementation of several `get<LedgerObject>` methods in the Explorer do not validate the type of ledger-objects. This has led to cases where user specifies the hash of a `PermissonedDomain` object however they are redirected to a `Vault` page incorrectly.

This bug was discovered with the input `EF98FDBA404CBEB4F746DA1026B859E260BBB459D111268F6A26BBC7C4811A04` on the XRPL Devnet. This value points to a `PermissionedDomain`, however users are incorrectly directly to the `Vault` Page.

Note: other rippled-related methods have not been updated in this PR because they have not exhibited a strong need for a strong response type-check. This also enables a nimble bug-fix PR.                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                 
Solution proposed in this PR:                                                                                                                                                
                                                                                                                                                                                                 
  - Add a `LedgerEntryType === 'Vault'` guard in `getVault`. Any other                                                                                                                           
    ledger entry type now rejects with `Error('Not a Vault', 404)`.                                                                                                                              
  - Add `src/rippled/lib/test/rippled.test.ts` with unit-test coverage                                                                                                                           
    for `getVault`'s success path and every error branch.     
    
    
This PR is deployed in the dev environment of the Explorer: https://devnet.dev.ripplex.io/. Typing the above hash in the `SearchBar` should show a message akin to "No txn/nft/vault found for this hash"/                                                                                                                                   

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
-->



<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release







<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

A new unit test file has been introduced.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
