### PR TITLE
Make maintenance window banner sticky on top of page

### DIFF
--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -6,23 +6,19 @@ import { SocketProvider } from '../shared/SocketContext'
 import { NetworkProvider } from '../shared/NetworkContext'
 import { Header } from '../Header'
 import { TooltipProvider } from '../shared/components/Tooltip'
-import { MaintenanceBanner } from '../shared/components/MaintenanceBanner'
 
 // memoize to prevent react-router from creating a new socket ever single time a rew route is loaded
 export const App: FC<{ rippledUrl: string }> = memo(
   ({ rippledUrl }: { rippledUrl: string }) => (
-    <>
-      <MaintenanceBanner />
-      <SocketProvider rippledUrl={rippledUrl}>
-        <NetworkProvider rippledUrl={rippledUrl}>
-          <TooltipProvider>
-            <Header inNetwork />
-            <div className="content">
-              <Outlet />
-            </div>
-          </TooltipProvider>
-        </NetworkProvider>
-      </SocketProvider>
-    </>
+    <SocketProvider rippledUrl={rippledUrl}>
+      <NetworkProvider rippledUrl={rippledUrl}>
+        <TooltipProvider>
+          <Header inNetwork />
+          <div className="content">
+            <Outlet />
+          </div>
+        </TooltipProvider>
+      </NetworkProvider>
+    </SocketProvider>
   ),
 )

--- a/src/containers/Header/index.tsx
+++ b/src/containers/Header/index.tsx
@@ -7,9 +7,11 @@ import { NavigationMenu } from './NavigationMenu'
 import './header.scss'
 import { LanguagePicker } from './LanguagePicker/LanguagePicker'
 import { NetworkPicker } from './NetworkPicker/NetworkPicker'
+import { MaintenanceBanner } from '../shared/components/MaintenanceBanner'
 
 export const Header: FC<{ inNetwork?: boolean }> = ({ inNetwork = true }) => (
   <header className={classnames('header', !inNetwork && 'header-no-network')}>
+    <MaintenanceBanner />
     <div className="topbar">
       <NetworkPicker />
       <LanguagePicker />

--- a/src/containers/shared/components/MaintenanceBanner/styles.scss
+++ b/src/containers/shared/components/MaintenanceBanner/styles.scss
@@ -3,13 +3,9 @@
 .maintenance-banner {
   padding: 14px 24px;
   border-radius: $border-radius;
-  margin: 12px;
+  margin-bottom: 8px;
   background: linear-gradient(135deg, $blue-purple-40 0%, $blue-purple-70 100%);
   color: $white;
-
-  @include for-size(desktop-up) {
-    margin: 16px 20px;
-  }
 
   &__content {
     display: flex;


### PR DESCRIPTION
## High Level Overview of Change

Pins the `MaintenanceBanner` to the sticky `Header` so it remains visible while users scroll, instead of disappearing off-screen with the page content.

- Moved `<MaintenanceBanner />` from `App.tsx` into `Header/index.tsx` as the first child of the `<header>` element.
- The Header already has `position: sticky; top: 0; z-index: 20`, so the banner now sticks with it as a single unit — no second sticky element, no z-index coordination needed.
- Dropped the banner's outer `margin` (the Header's `padding: 16px` handles outer spacing); added `margin-bottom: 8px` to keep visual separation from the network/language pickers below.

### Context of Change

Follow-up to the original maintenance banner PR. While testing the scheduled window, the banner was scrolling out of view as soon as the user moved past the top of the page — defeating the point of a persistent announcement during a 30-minute outage window. The cleanest fix was to make it part of the existing sticky Header rather than introduce a second sticky context.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Translation Updates
- [ ] Release

### Codebase Modernization

- [] Updated files to React Hooks
- [] Updated files to TypeScript

## Before / After

**Before:** https://livenet.stg.ripplex.io/
Banner appears at the top of the page in normal document flow. Scrolling down a few hundred pixels scrolls it off-screen. The sticky Header below it remains visible; the announcement does not.


**After:** https://livenet.dev.ripplex.io/ 
Banner is part of the sticky Header block. Stays pinned to the top of the viewport throughout the user's session for the entire scroll length of every page.


## Test Plan

**Automated:** existing `MaintenanceBanner` unit tests still pass unchanged (`npm test -- MaintenanceBanner` — 6 cases).

**Manual:**

- [x] `npm start`, set `MAINTENANCE_START` to a few minutes in the future locally → banner appears at top
- [x] Scroll down the page → banner stays pinned at top alongside the network/language pickers and navigation
- [x] Visit `/transactions`, `/validators`, `/ledgers/<n>`, `/accounts/<addr>` → banner sticks on every route
- [x] Mobile viewport: banner stacks above topbar inside the sticky header without overlapping or layout breaks
