### PR TITLE
fix: Nft mutable flag

### DIFF
--- a/public/locales/en-US/translations.json
+++ b/public/locales/en-US/translations.json
@@ -461,6 +461,7 @@
   "burnable": "Burnable",
   "only_xrp": "Only XRP",
   "transferable": "Transferable",
+  "mutable": "Mutable",
   "buy_offers": "Buy Offers",
   "sell_offers": "Sell Offers",
   "offer_index": "Offer ID",

--- a/src/containers/NFT/NFTHeader/Settings.tsx
+++ b/src/containers/NFT/NFTHeader/Settings.tsx
@@ -14,6 +14,7 @@ export const Settings = ({ flags }: Props) => {
   const transferable = flags.includes('lsfTransferable')
     ? 'enabled'
     : 'disabled'
+  const mutable = flags.includes('lsfMutable') ? 'enabled' : 'disabled'
 
   return (
     <table className="token-table">
@@ -21,6 +22,7 @@ export const Settings = ({ flags }: Props) => {
         <TokenTableRow label={t('burnable')} value={burnable} />
         <TokenTableRow label={t('only_xrp')} value={onlyXRP} />
         <TokenTableRow label={t('transferable')} value={transferable} />
+        <TokenTableRow label={t('mutable')} value={mutable} />
       </tbody>
     </table>
   )

--- a/src/containers/NFT/NFTHeader/test/Settings.test.js
+++ b/src/containers/NFT/NFTHeader/test/Settings.test.js
@@ -19,8 +19,8 @@ describe('NFT Setttings container', () => {
 
   it('renders defined fields', () => {
     const { container } = renderSettings()
-    expect(container.querySelectorAll('.row').length).toEqual(3)
+    expect(container.querySelectorAll('.row').length).toEqual(4)
     expect((container.textContent.match(/enabled/g) || []).length).toEqual(2)
-    expect((container.textContent.match(/disabled/g) || []).length).toEqual(1)
+    expect((container.textContent.match(/disabled/g) || []).length).toEqual(2)
   })
 })

--- a/src/containers/shared/test/transactionUtils.test.ts
+++ b/src/containers/shared/test/transactionUtils.test.ts
@@ -1,0 +1,27 @@
+import { Transaction } from '../components/Transaction/types'
+import { buildFlags } from '../transactionUtils'
+
+const buildNFTokenMint = (flags: number): Transaction =>
+  ({
+    tx: {
+      TransactionType: 'NFTokenMint',
+      Flags: flags,
+    },
+  }) as unknown as Transaction
+
+describe('transactionUtils buildFlags', () => {
+  it('decodes NFTokenMint type-specific flags', () => {
+    expect(buildFlags(buildNFTokenMint(0x00000001))).toEqual(['tfBurnable'])
+    expect(buildFlags(buildNFTokenMint(0x00000008))).toEqual(['tfTransferable'])
+  })
+
+  it('decodes the tfMutable flag (XLS-46 dynamic NFTs)', () => {
+    expect(buildFlags(buildNFTokenMint(0x00000010))).toEqual(['tfMutable'])
+  })
+
+  it('decodes multiple NFTokenMint flags including tfMutable', () => {
+    expect(
+      buildFlags(buildNFTokenMint(0x00000001 | 0x00000008 | 0x00000010)),
+    ).toEqual(['tfMutable', 'tfTransferable', 'tfBurnable'])
+  })
+})

--- a/src/containers/shared/transactionUtils.ts
+++ b/src/containers/shared/transactionUtils.ts
@@ -82,6 +82,7 @@ export const TX_FLAGS: Record<string, Record<number, string>> = {
     0x00000002: 'tfOnlyXRP',
     0x00000004: 'tfTrustLine',
     0x00000008: 'tfTransferable',
+    0x00000010: 'tfMutable',
   },
   NFTokenOfferCreate: {
     0x00000001: 'tfSellNFToken',

--- a/src/rippled/lib/utils.ts
+++ b/src/rippled/lib/utils.ts
@@ -36,6 +36,7 @@ const NFT_FLAGS: FlagMap = {
   0x00000001: 'lsfBurnable',
   0x00000002: 'lsfOnlyXRP',
   0x00000008: 'lsfTransferable',
+  0x00000010: 'lsfMutable',
 }
 const MPT_ISSUANCE_FLAGS: FlagMap = {
   0x00000001: 'lsfMPTLocked',


### PR DESCRIPTION
## High Level Overview of Change



Adds support for the lsfMutable flag on NFTs so that an NFT's Mutable setting is surfaced in the explorer UI.



  - Maps the 0x00000010 NFT flag to lsfMutable in src/rippled/lib/utils.ts

  - Renders a new Mutable row (enabled/disabled) in the NFT Settings table (Settings.tsx)

  - Adds the mutable translation string (en-US)

  - Updates the Settings test to expect the additional row



### Context of Change



The XLS-46 dynamic NFT (lsfMutable) flag allows an NFT's URI to be modified after minting. The explorer's NFT Settings table decoded lsfBurnable, lsfOnlyXRP, and lsfTransferable, but not lsfMutable, so mutable NFTs gave no indication of their mutability in the UI. This change decodes the flag and displays it alongside the other settings, matching the existing pattern for those flags.



### Type of Change



- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Refactor (non-breaking change that only restructures code)

- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)

- [ ] Documentation Updates

- [x] Translation Updates

- [ ] Release



### Codebase Modernization

- [x ] Updated files to React Hooks

- [x ] Updated files to TypeScript



## Before / After



### NFT page → Settings

**Before:** Showed Burnable, Only XRP, Transferable only. Mutable NFTs gave no indication of mutability.

**After:** Adds a Mutable row showing enabled/disabled.

<img width="819" height="455" alt="Screenshot 2026-06-22 at 11 10 42 AM" src="https://github.com/user-attachments/assets/6146d6dc-cd14-481b-be7f-05c332eed4dc" />

### NFTokenMint → Detailed tab

**Before:** Flags displayed `0x00000010` as raw, unlabeled hex alongside tfTransferable, tfBurnable.

**After:** Displays `tfMutable` for that bit.

<img width="735" height="648" alt="Screenshot 2026-06-22 at 11 09 55 AM" src="https://github.com/user-attachments/assets/e2804088-6c43-4f38-afe7-2c517118394c" />



## Test Plan



- Updated Settings.test.js to expect 4 rows with the correct enabled/disabled counts; ran the affected unit suites (Settings + NFTokenMint) — all green.

- Manually verified on testnet (Clio) with a minted dynamic NFT:

  - NFT page Settings shows Mutable: enabled; a non-mutable NFT shows Mutable: disabled.

  - NFTokenMint Detailed tab labels the flag as `tfMutable`.

