### PR TITLE
upgrade status: Strip the  prefix (not just legacy ) so a release isn't split across two bars after the rippled -> xrpld rename.

### DIFF
--- a/src/containers/Network/UpgradeStatus.tsx
+++ b/src/containers/Network/UpgradeStatus.tsx
@@ -124,18 +124,19 @@ export const aggregateData = (
  * (https://data.xrpl.org/v1/network/topology/nodes)
  *
  * Node versions often come in in this format:
- * rippled-[version]-[release (optional)]+[rippled hash (optional)]
+ * (rippled|xrpld)-[version]-[release (optional)]+[hash (optional)]
  * Output format:
  * [version]-[release (optional)]
  * e.g. rippled-1.9.4+ba3c0e51455a88d76d90b996f20c0f102ac3f5a0.DEBUG should returns 1.9.4
  *      rippled-1.9.4-b1 should returns 1.9.4-b1
+ *      xrpld-3.2.0 should returns 3.2.0
  *
  * @param version - The version retrieved from source data.
  * @returns - The correct version format.
  */
-const handleNodeVersion = (version: string | undefined) => {
+export const handleNodeVersion = (version: string | undefined) => {
   let cleanedVersion = version
-  if (version?.startsWith('rippled'))
+  if (version?.startsWith('rippled') || version?.startsWith('xrpld'))
     cleanedVersion = `${version.split('-').slice(1).join('-')}`
   if (version?.includes('+'))
     cleanedVersion = `${cleanedVersion?.split('+')[0]}`

--- a/src/containers/Network/test/upgradeStatus.test.js
+++ b/src/containers/Network/test/upgradeStatus.test.js
@@ -12,6 +12,7 @@ import {
   aggregateData,
   aggregateNodes,
   aggregateValidators,
+  handleNodeVersion,
 } from '../UpgradeStatus'
 import { UPGRADE_STATUS_ROUTE } from '../../App/routes'
 
@@ -76,6 +77,38 @@ const nodesData = [
     timezone: 'America/Los_Angeles',
   },
 ]
+
+describe('handleNodeVersion', () => {
+  it('strips the rippled- prefix', () => {
+    expect(handleNodeVersion('rippled-3.1.3')).toEqual('3.1.3')
+  })
+
+  it('strips the xrpld- prefix', () => {
+    expect(handleNodeVersion('xrpld-3.2.0')).toEqual('3.2.0')
+  })
+
+  it('preserves the release suffix', () => {
+    expect(handleNodeVersion('xrpld-3.2.0-b7')).toEqual('3.2.0-b7')
+    expect(handleNodeVersion('rippled-1.9.4-b1')).toEqual('1.9.4-b1')
+  })
+
+  it('strips the build hash after +', () => {
+    expect(
+      handleNodeVersion(
+        'xrpld-3.3.0-b0+9af4fb521e169c056f9eff16779195b7146e8f92.DEBUG',
+      ),
+    ).toEqual('3.3.0-b0')
+    expect(
+      handleNodeVersion(
+        'rippled-1.9.4+ba3c0e51455a88d76d90b996f20c0f102ac3f5a0.DEBUG',
+      ),
+    ).toEqual('1.9.4')
+  })
+
+  it('leaves an already-clean version untouched', () => {
+    expect(handleNodeVersion('3.2.0')).toEqual('3.2.0')
+  })
+})
 
 describe('UpgradeStatus test functions', () => {
   it('aggregate data works with validators without keys', () => {


### PR DESCRIPTION
## High Level Overview of Change

The Upgrade Status page (`/network/upgrade-status`) displayed a single rippled release as two separate bars — e.g. `xrpld-3.2.0` and `3.2.0`. This PR normalizes the `xrpld-` prefix so prefixed and bare version strings aggregate into one bucket.

### Context of Change
`handleNodeVersion` cleans the version strings returned by the VHS topology endpoint (`data.xrpl.org/v1/network/topology/nodes/{network}`) before they're aggregated. It only stripped the `rippled-` prefix.

After rippled was renamed to **xrpld**, newer peers self-report as `xrpld-3.2.0`, which failed the `startsWith('rippled')` check and was left untouched — so it never merged with the bare `3.2.0` values that validators (and VHS) report. Live data confirmed the split: `xrpld-3.2.0` (221 nodes) and `3.2.0` (98) appeared as distinct versions, as did `rippled-3.1.3` (286) vs `3.1.3` (168).

The fix extends the prefix check to also strip `xrpld-`. The existing `+hash` suffix handling already covers debug builds like `xrpld-3.3.0-b0+<hash>.DEBUG`. The GitHub stable-release tag is already prefix-free (`3.2.0`), so no change was needed there.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

### Codebase Modernization

- [ ] Updated files to React Hooks
- [ ] Updated files to TypeScript

N/A — the touched files are already Hooks + TypeScript.

## Before / After

**Before:** `xrpld-3.2.0` and `3.2.0` (and `rippled-3.1.3` / `3.1.3`) rendered as separate bars, fragmenting version-adoption counts.

**After:** Prefixed versions normalize to their bare form (`xrpld-3.2.0` → `3.2.0`), merging with validator/node buckets and the GitHub stable tag into a single accurate bar per release.

## Test Plan

- Added a `handleNodeVersion` unit test block covering: `rippled-` and `xrpld-` prefix stripping, release-suffix preservation (`-b7`), `+hash.DEBUG` stripping, and already-clean versions.
- Manual test
